### PR TITLE
Optimize the QpMap processing and add a compute filter to the encoder.

### DIFF
--- a/common/libs/VkCodecUtils/VulkanCommandBufferPool.cpp
+++ b/common/libs/VkCodecUtils/VulkanCommandBufferPool.cpp
@@ -108,7 +108,7 @@ bool VulkanCommandBufferPool::ReleasePoolNodeToPool(uint32_t poolNodeIndex)
 VkResult VulkanCommandBufferPool::Create(const VulkanDeviceContext* vkDevCtx,
                                          VkSharedBaseObj<VulkanCommandBufferPool>& cmdBuffPool)
 {
-    VkSharedBaseObj<VulkanCommandBufferPool> _cmdBuffPool(new VulkanCommandBufferPool());
+    VkSharedBaseObj<VulkanCommandBufferPool> _cmdBuffPool(new VulkanCommandBufferPool(vkDevCtx));
 
     if (_cmdBuffPool) {
         cmdBuffPool = _cmdBuffPool;

--- a/common/libs/VkCodecUtils/VulkanCommandBufferPool.h
+++ b/common/libs/VkCodecUtils/VulkanCommandBufferPool.h
@@ -202,6 +202,14 @@ public:
             return m_parent->m_queryPoolSet.GetQueryPool(queryIdx);
         }
 
+        uint32_t GetNodePoolIndex() const {
+            if ((m_parent == nullptr) || (m_parentIndex < 0)) {
+                assert(!"Invalid PoolNode state!");
+                return (uint32_t)-1;
+            }
+            return m_parentIndex;
+        }
+
         const VulkanDeviceContext* GetDeviceContext() const { return m_vkDevCtx; }
 
     private:
@@ -217,8 +225,8 @@ public:
 
     static constexpr size_t maxPoolNodes = 64;
 
-    VulkanCommandBufferPool()
-        : m_vkDevCtx()
+    VulkanCommandBufferPool(const VulkanDeviceContext* vkDevCtx)
+        : m_vkDevCtx(vkDevCtx)
         , m_refCount()
         , m_queueMutex()
         , m_poolSize(0)
@@ -281,8 +289,9 @@ public:
 
     bool ReleasePoolNodeToPool(uint32_t poolNodeIndex);
 
-private:
+protected:
     const VulkanDeviceContext* m_vkDevCtx;
+private:
     std::atomic<int32_t>       m_refCount;
     std::mutex                 m_queueMutex;
     uint32_t                   m_poolSize;

--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
@@ -56,8 +56,15 @@ VkResult VulkanFilterYuvCompute::Create(const VulkanDeviceContext* vkDevCtx,
 VkResult VulkanFilterYuvCompute::Init(const VkSamplerYcbcrConversionCreateInfo* pYcbcrConversionCreateInfo,
                                       const VkSamplerCreateInfo* pSamplerCreateInfo)
 {
+    VkResult result = Configure( m_vkDevCtx,
+                                 m_maxNumFrames, // numPoolNodes
+                                 m_vkDevCtx->GetComputeQueueFamilyIdx(), // queueFamilyIndex
+                                 false,    // createQueryPool - not needed for the compute filter
+                                 nullptr,  // pVideoProfile   - not needed for the compute filter
+                                 true,     // createSemaphores
+                                 true      // createFences
+                                );
 
-    VkResult result = VK_SUCCESS;
     if (pYcbcrConversionCreateInfo) {
          result = m_samplerYcbcrConversion.CreateVulkanSampler(m_vkDevCtx,
                                                                pSamplerCreateInfo,
@@ -73,27 +80,6 @@ VkResult VulkanFilterYuvCompute::Init(const VkSamplerYcbcrConversionCreateInfo* 
     result = InitDescriptorSetLayout(m_maxNumFrames);
     if (result != VK_SUCCESS) {
         assert(!"ERROR: InitDescriptorSetLayout!");
-        return result;
-    }
-
-    result = m_commandBuffersSet.CreateCommandBufferPool(m_vkDevCtx, m_queueFamilyIndex, m_maxNumFrames);
-    if (result != VK_SUCCESS) {
-        assert(!"ERROR: CreateCommandBufferPool!");
-        return result;
-    }
-
-    result = m_filterWaitSemaphoreSet.CreateSet(m_vkDevCtx, m_maxNumFrames);
-    if (result != VK_SUCCESS) {
-        assert(!"ERROR: m_filterWaitSemaphoreSet.CreateSet!");
-        return result;
-    }
-
-    // Before start recording the command buffer, the filter waits on the corresponding fence
-    // For the first frame, however, there is not command buffer submission, so we need to create
-    // the fence signaled. See RecordCommandBuffer()
-    result = m_filterCompleteFenceSet.CreateSet(m_vkDevCtx, m_maxNumFrames, VK_FENCE_CREATE_SIGNALED_BIT);
-    if (result != VK_SUCCESS) {
-        assert(!"ERROR: CreateCommandBufferPool!");
         return result;
     }
 

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
@@ -249,10 +249,9 @@ int32_t VulkanVideoProcessor::GetBitDepth()  const
 
 void VulkanVideoProcessor::Deinit()
 {
-
     m_vkParser = nullptr;
-    m_vkVideoDecoder = nullptr;
     m_vkVideoFrameBuffer = nullptr;
+    m_vkVideoDecoder = nullptr;
     m_videoStreamDemuxer = nullptr;
 }
 

--- a/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
+++ b/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
@@ -74,6 +74,8 @@ set(sources
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanBistreamBufferImpl.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanBistreamBufferImpl.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/crcgenerator.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBufferPool.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBufferPool.h
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/FFmpegDemuxer.cpp
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/VideoStreamDemuxer.cpp
     ${VK_VIDEO_DECODER_LIBS_SOURCE_ROOT}/VkDecoderUtils/VideoStreamDemuxer.h

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -228,9 +228,10 @@ int main(int argc, const char **argv) {
     } else {
 
         result = vkDevCtxt.InitPhysicalDevice(programConfig.deviceId, programConfig.GetDeviceUUID(),
-                                              (VK_QUEUE_TRANSFER_BIT | requestVideoDecodeQueueMask  |
-                                              requestVideoComputeQueueMask |
-                                              requestVideoEncodeQueueMask),
+                                              (VK_QUEUE_TRANSFER_BIT        |
+                                               requestVideoDecodeQueueMask  |
+                                               requestVideoComputeQueueMask |
+                                               requestVideoEncodeQueueMask),
                                               nullptr,
                                               requestVideoDecodeQueueMask);
         if (result != VK_SUCCESS) {

--- a/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
+++ b/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
@@ -168,6 +168,8 @@ public:
     // The bitstream Buffer
     VkSharedBaseObj<VkVideoRefCountBase>  bitstreamData;
 
+    // The filter's pool node
+    VkSharedBaseObj<VkVideoRefCountBase>  filterPoolNode;
 private:
     const VulkanDeviceContext*  m_vkDevCtx;
     std::array<ImageViewState, DecodeFrameBufferIf::MAX_PER_FRAME_IMAGE_TYPES> m_imageViewState;
@@ -432,6 +434,7 @@ public:
         m_perFrameDecodeImageSet[picId].stdSps = const_cast<VkVideoRefCountBase*>(pReferencedObjectsInfo->pStdSps);
         m_perFrameDecodeImageSet[picId].stdVps = const_cast<VkVideoRefCountBase*>(pReferencedObjectsInfo->pStdVps);
         m_perFrameDecodeImageSet[picId].bitstreamData = const_cast<VkVideoRefCountBase*>(pReferencedObjectsInfo->pBitstreamData);
+        m_perFrameDecodeImageSet[picId].filterPoolNode = const_cast<VkVideoRefCountBase*>(pReferencedObjectsInfo->pFilterPoolNode);
 
         if (m_debug) {
             std::cout << "==> Queue Decode Picture picIdx: " << (uint32_t)picId

--- a/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.h
+++ b/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.h
@@ -89,14 +89,18 @@ public:
         // VPS
         const VkVideoRefCountBase*     pStdVps;
 
+        const VkVideoRefCountBase*     pFilterPoolNode;
+
         ReferencedObjectsInfo(const VkVideoRefCountBase* pBitstreamDataRef,
                               const VkVideoRefCountBase* pStdPpsRef,
                               const VkVideoRefCountBase* pStdSpsRef,
-                              const VkVideoRefCountBase* pStdVpsRef = nullptr)
+                              const VkVideoRefCountBase* pStdVpsRef = nullptr,
+                              const VkVideoRefCountBase* pFilterPoolNodeRef = nullptr)
         : pBitstreamData(pBitstreamDataRef)
         , pStdPps(pStdPpsRef)
         , pStdSps(pStdSpsRef)
-        , pStdVps(pStdVpsRef) {}
+        , pStdVps(pStdVpsRef)
+        , pFilterPoolNode(pFilterPoolNodeRef) {}
     };
 
     struct PictureResourceInfo {

--- a/vk_video_encoder/demos/vk-video-enc/CMakeLists.txt
+++ b/vk_video_encoder/demos/vk-video-enc/CMakeLists.txt
@@ -50,9 +50,9 @@ set(sources
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceContext.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceContext.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceMemoryImpl.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceMemoryImpl.cpp
-    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkBufferResource.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkBufferResource.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkImageResource.cpp
@@ -67,8 +67,6 @@ set(sources
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDescriptorSetLayout.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBuffersSet.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanCommandBuffersSet.h
-    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.cpp
-    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSession.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSession.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.cpp
@@ -84,6 +82,8 @@ set(sources
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/pattern.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoUtils.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoUtils.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilter.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilter.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilterYuvCompute.cpp

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -135,6 +135,11 @@ int main(int argc, char** argv)
         }
     }
 
+    VkQueueFlags requestVideoComputeQueueMask = 0;
+    if (encoderConfig->enablePreprocessComputeFilter == VK_TRUE) {
+        requestVideoComputeQueueMask = VK_QUEUE_COMPUTE_BIT;
+    }
+
     VkSharedBaseObj<VulkanVideoDisplayQueue<VulkanEncoderInputFrame>> videoDispayQueue;
     result = CreateVulkanVideoEncodeDisplayQueue(&vkDevCtxt,
                                                  encoderConfig->encodeWidth,
@@ -180,7 +185,10 @@ int main(int argc, char** argv)
         }
 
         result = vkDevCtxt.InitPhysicalDevice(encoderConfig->deviceId, encoderConfig->GetDeviceUUID(),
-                                              (VK_QUEUE_GRAPHICS_BIT | requestVideoDecodeQueueMask | requestVideoEncodeQueueMask),
+                                              (VK_QUEUE_GRAPHICS_BIT |
+                                                      requestVideoComputeQueueMask |
+                                                      requestVideoDecodeQueueMask  |
+                                                      requestVideoEncodeQueueMask),
                                               displayShell,
                                               requestVideoDecodeQueueMask,
                                               (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR |
@@ -203,7 +211,8 @@ int main(int argc, char** argv)
                                               false,             // createTransferQueue
                                               true,              // createGraphicsQueue
                                               true,              // createDisplayQueue
-                                              (encoderConfig->selectVideoWithComputeQueue == 1)  // createComputeQueue
+                                              ((encoderConfig->selectVideoWithComputeQueue == 1) ||  // createComputeQueue
+                                               (encoderConfig->enablePreprocessComputeFilter == VK_TRUE))
                                               );
         if (result != VK_SUCCESS) {
 
@@ -227,7 +236,10 @@ int main(int argc, char** argv)
 
         // No display presentation and no decoder - just the encoder
         result = vkDevCtxt.InitPhysicalDevice(encoderConfig->deviceId, encoderConfig->GetDeviceUUID(),
-                                              (requestVideoDecodeQueueMask | requestVideoEncodeQueueMask | VK_QUEUE_TRANSFER_BIT),
+                                              (requestVideoComputeQueueMask |
+                                               requestVideoDecodeQueueMask  |
+                                               requestVideoEncodeQueueMask  |
+                                               VK_QUEUE_TRANSFER_BIT),
                                               nullptr,
                                               requestVideoDecodeQueueMask,
                                               (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR |
@@ -251,7 +263,8 @@ int main(int argc, char** argv)
                                               ((vkDevCtxt.GetVideoEncodeQueueFlag() & VK_QUEUE_TRANSFER_BIT) == 0), //  createTransferQueue
                                               false, // createGraphicsQueue
                                               false, // createDisplayQueue
-                                              (encoderConfig->selectVideoWithComputeQueue == 1)  // createComputeQueue
+                                              ((encoderConfig->selectVideoWithComputeQueue == 1) ||  // createComputeQueue
+                                               (encoderConfig->enablePreprocessComputeFilter == VK_TRUE))
                                               );
         if (result != VK_SUCCESS) {
 

--- a/vk_video_encoder/libs/CMakeLists.txt
+++ b/vk_video_encoder/libs/CMakeLists.txt
@@ -77,6 +77,8 @@ set(LIBVKVIDEOENCODER
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/HelpersDispatchTable.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceContext.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceContext.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanShaderCompiler.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceMemoryImpl.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanDeviceMemoryImpl.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VkBufferResource.cpp
@@ -99,6 +101,12 @@ set(LIBVKVIDEOENCODER
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanVideoSessionParameters.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/pattern.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/pattern.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanComputePipeline.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilter.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilter.h
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilterYuvCompute.cpp
+    ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFilterYuvCompute.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanSamplerYcbcrConversion.cpp
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanSamplerYcbcrConversion.h
     ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT}/VkCodecUtils/VulkanFenceSet.cpp
@@ -115,8 +123,11 @@ include_directories(BEFORE "${CMAKE_CURRENT_LIST_DIR}/../")
 include_directories(BEFORE ${VULKAN_VIDEO_ENCODER_INCLUDE}/../libs)
 include_directories(BEFORE ${VULKAN_VIDEO_ENCODER_INCLUDE})
 include_directories(BEFORE ${VK_VIDEO_COMMON_LIBS_SOURCE_ROOT})
+include_directories(BEFORE ${SHADERC_ROOT_PATH}/install/include)
 
 add_library(${VULKAN_VIDEO_ENCODER_LIB} SHARED ${LIBVKVIDEOENCODER})
+# Link the libraries
+target_link_libraries(${VULKAN_VIDEO_ENCODER_LIB} PUBLIC ${GLSLANG_LIBRARIES})
 # Ensure the library depends on the generation of these files
 add_dependencies(${VULKAN_VIDEO_ENCODER_LIB} GenerateDispatchTables)
 
@@ -141,6 +152,8 @@ if(WIN32)
 endif()
 
 add_library(${VULKAN_VIDEO_ENCODER_STATIC_LIB} STATIC ${LIBVKVIDEOENCODER})
+# Link the libraries
+target_link_libraries(${VULKAN_VIDEO_ENCODER_STATIC_LIB} PUBLIC ${GLSLANG_LIBRARIES})
 # Ensure the library depends on the generation of these files
 add_dependencies(${VULKAN_VIDEO_ENCODER_STATIC_LIB} GenerateDispatchTables)
 target_include_directories(${VULKAN_VIDEO_ENCODER_STATIC_LIB} PUBLIC ${VULKAN_VIDEO_ENCODER_INCLUDE} ${VULKAN_VIDEO_ENCODER_INCLUDE}/../NvVideoParser PRIVATE include)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -831,8 +831,8 @@ public:
     , enableVideoDecoder(false)
     , enableHwLoadBalancing(false)
     , selectVideoWithComputeQueue(false)
-    , enableOutOfOrderRecording(false)
     , enablePreprocessComputeFilter(false)
+    , enableOutOfOrderRecording(false)
     { }
 
     virtual ~EncoderConfig() {}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -31,6 +31,7 @@
 #include "VkVideoEncoder/VkVideoGopStructure.h"
 #include "VkVideoCore/VkVideoCoreProfile.h"
 #include "VkVideoCore/VulkanVideoCapabilities.h"
+#include "VkCodecUtils/VulkanFilterYuvCompute.h"
 
 struct EncoderConfigH264;
 struct EncoderConfigH265;
@@ -731,6 +732,9 @@ public:
     EncoderInputFileHandler inputFileHandler;
     EncoderOutputFileHandler outputFileHandler;
     EncoderQpMapFileHandler qpMapFileHandler;
+
+    VulkanFilterYuvCompute::FilterType filterType;
+
     uint32_t validate : 1;
     uint32_t validateVerbose : 1;
     uint32_t verbose : 1;
@@ -741,6 +745,7 @@ public:
     uint32_t enableVideoDecoder : 1;
     uint32_t enableHwLoadBalancing : 1;
     uint32_t selectVideoWithComputeQueue : 1;
+    uint32_t enablePreprocessComputeFilter : 1;
     uint32_t enableOutOfOrderRecording : 1; // Testing only - don't use for production!
 
     EncoderConfig()
@@ -815,6 +820,7 @@ public:
     , max_dec_frame_buffering()
     , chroma_sample_loc_type()
     , inputFileHandler()
+    , filterType(VulkanFilterYuvCompute::YCBCRCOPY)
     , validate(false)
     , validateVerbose(false)
     , verbose(false)
@@ -826,6 +832,7 @@ public:
     , enableHwLoadBalancing(false)
     , selectVideoWithComputeQueue(false)
     , enableOutOfOrderRecording(false)
+    , enablePreprocessComputeFilter(false)
     { }
 
     virtual ~EncoderConfig() {}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -517,8 +517,11 @@ public:
     VkResult LoadNextFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult LoadNextQpMapFrameFromFile(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult StageInputFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
+    VkResult StageInputFrameQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
+                                  VkCommandBuffer cmdBuf = VK_NULL_HANDLE);
     VkResult SubmitStagedInputFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult SubmitStagedQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
+    VkResult EncodeFrameCommon(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     virtual VkResult EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo) = 0; // Must be implemented by the codec
     virtual VkResult HandleCtrlCmd(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -515,6 +515,7 @@ public:
 
     virtual VkResult InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& encoderConfig) = 0; // Must be implemented by the codec
     VkResult LoadNextFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
+    VkResult LoadNextQpMapFrameFromFile(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult StageInputFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult SubmitStagedInputFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
     VkResult SubmitStagedQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
@@ -574,6 +575,8 @@ protected:
                                      uint32_t dstCopyArrayLayer = 0,
                                      VkImageLayout srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                      VkImageLayout dstImageLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+    void ProcessQpMap(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo);
 
     virtual VkResult ProcessDpb(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
                                 uint32_t frameIdx, uint32_t ofTotalFrames) = 0;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -702,6 +702,7 @@ protected:
     VkSharedBaseObj<VulkanVideoImagePool>    m_linearInputImagePool;
     VkSharedBaseObj<VulkanVideoImagePool>    m_inputImagePool;
     VkSharedBaseObj<VulkanVideoImagePool>    m_dpbImagePool;
+    VkSharedBaseObj<VulkanFilter>            m_inputComputeFilter;
     VkSharedBaseObj<VulkanCommandBufferPool> m_inputCommandBufferPool;
     VkSharedBaseObj<VulkanCommandBufferPool> m_encodeCommandBufferPool;
     VulkanBitstreamBufferPool                m_bitstreamBuffersQueue;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -96,7 +96,7 @@ public:
             , setupImageResource()
             , outputBitstreamBuffer()
             , dpbImageResources()
-            , srcQpMapStagingImageView()
+            , srcQpMapStagingResource()
             , srcQpMapImageResource()
             , qpMapCmdBuffer()
             , m_refCount(0)
@@ -152,7 +152,7 @@ public:
         VkSharedBaseObj<VulkanCommandBufferPool::PoolNode> encodeCmdBuffer;
         VkSharedBaseObj<VkVideoEncodeFrameInfo>            dependantFrames;
 
-        VkSharedBaseObj<VulkanVideoImagePoolNode>          srcQpMapStagingImageView;
+        VkSharedBaseObj<VulkanVideoImagePoolNode>          srcQpMapStagingResource;
         VkSharedBaseObj<VulkanVideoImagePoolNode>          srcQpMapImageResource;
         VkSharedBaseObj<VulkanCommandBufferPool::PoolNode> qpMapCmdBuffer;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -551,19 +551,7 @@ VkResult VkVideoEncoderAV1::EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>&
     }
 
     if (m_encoderConfig->enableQpMap) {
-        VkVideoPictureResourceInfoKHR* pSrcQpMapPictureResource = encodeFrameInfo->srcQpMapImageResource->GetPictureResourceInfo();
-        encodeFrameInfo->quantizationMapInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_INFO_KHR;
-        encodeFrameInfo->quantizationMapInfo.pNext = nullptr;
-        encodeFrameInfo->quantizationMapInfo.quantizationMap = pSrcQpMapPictureResource->imageViewBinding;
-        encodeFrameInfo->quantizationMapInfo.quantizationMapExtent = { (m_encoderConfig->encodeWidth + m_qpMapTexelSize.width - 1) / m_qpMapTexelSize.width,
-                                                                       (m_encoderConfig->encodeHeight + m_qpMapTexelSize.height - 1) / m_qpMapTexelSize.height };
-
-        VkBaseInStructure* pStruct = (VkBaseInStructure*)&encodeFrameInfo->encodeInfo;
-        while (pStruct->pNext) pStruct = (VkBaseInStructure*)pStruct->pNext;
-        pStruct->pNext = (VkBaseInStructure*)&encodeFrameInfo->quantizationMapInfo;
-        encodeFrameInfo->encodeInfo.flags |= ((m_encoderConfig->qpMapMode == EncoderConfig::DELTA_QP_MAP) ?
-                                                VK_VIDEO_ENCODE_WITH_QUANTIZATION_DELTA_MAP_BIT_KHR :
-                                                VK_VIDEO_ENCODE_WITH_EMPHASIS_MAP_BIT_KHR);
+        ProcessQpMap(encodeFrameInfo);
     }
 
     EnqueueFrame(encodeFrameInfo, pFrameInfo->bIsKeyFrame, pFrameInfo->bIsReference);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.cpp
@@ -590,19 +590,7 @@ VkResult VkVideoEncoderH264::EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>
     //}
 
     if (m_encoderConfig->enableQpMap) {
-        VkVideoPictureResourceInfoKHR* pSrcQpMapPictureResource = encodeFrameInfo->srcQpMapImageResource->GetPictureResourceInfo();
-        encodeFrameInfo->quantizationMapInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_INFO_KHR;
-        encodeFrameInfo->quantizationMapInfo.pNext = nullptr;
-        encodeFrameInfo->quantizationMapInfo.quantizationMap = pSrcQpMapPictureResource->imageViewBinding;
-        encodeFrameInfo->quantizationMapInfo.quantizationMapExtent = { (m_encoderConfig->encodeWidth + m_qpMapTexelSize.width - 1) / m_qpMapTexelSize.width,
-                                                                       (m_encoderConfig->encodeHeight + m_qpMapTexelSize.height - 1) / m_qpMapTexelSize.height };
-
-        VkBaseInStructure* pStruct = (VkBaseInStructure*)&encodeFrameInfo->encodeInfo;
-        while (pStruct->pNext) pStruct = (VkBaseInStructure*)pStruct->pNext;
-        pStruct->pNext = (VkBaseInStructure*)&encodeFrameInfo->quantizationMapInfo;
-        encodeFrameInfo->encodeInfo.flags |= ((m_encoderConfig->qpMapMode == EncoderConfig::DELTA_QP_MAP) ?
-                                                VK_VIDEO_ENCODE_WITH_QUANTIZATION_DELTA_MAP_BIT_KHR :
-                                                VK_VIDEO_ENCODE_WITH_EMPHASIS_MAP_BIT_KHR);
+        ProcessQpMap(encodeFrameInfo);
     }
 
     // NOTE: dstBuffer resource acquisition can be deferred at the last moment before submit

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.cpp
@@ -519,19 +519,7 @@ VkResult VkVideoEncoderH265::EncodeFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>
     }
 
     if (m_encoderConfig->enableQpMap) {
-        VkVideoPictureResourceInfoKHR* pSrcQpMapPictureResource = encodeFrameInfo->srcQpMapImageResource->GetPictureResourceInfo();
-        encodeFrameInfo->quantizationMapInfo.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_INFO_KHR;
-        encodeFrameInfo->quantizationMapInfo.pNext = nullptr;
-        encodeFrameInfo->quantizationMapInfo.quantizationMap = pSrcQpMapPictureResource->imageViewBinding;
-        encodeFrameInfo->quantizationMapInfo.quantizationMapExtent = { (m_encoderConfig->encodeWidth + m_qpMapTexelSize.width - 1) / m_qpMapTexelSize.width,
-                                                                       (m_encoderConfig->encodeHeight + m_qpMapTexelSize.height - 1) / m_qpMapTexelSize.height };
-
-        VkBaseInStructure* pStruct = (VkBaseInStructure*)&encodeFrameInfo->encodeInfo;
-        while (pStruct->pNext) pStruct = (VkBaseInStructure*)pStruct->pNext;
-        pStruct->pNext = (VkBaseInStructure*)&encodeFrameInfo->quantizationMapInfo;
-        encodeFrameInfo->encodeInfo.flags |= ((m_encoderConfig->qpMapMode == EncoderConfig::DELTA_QP_MAP) ?
-                                                VK_VIDEO_ENCODE_WITH_QUANTIZATION_DELTA_MAP_BIT_KHR :
-                                                VK_VIDEO_ENCODE_WITH_EMPHASIS_MAP_BIT_KHR);
+        ProcessQpMap(encodeFrameInfo);
     }
 
     EnqueueFrame(encodeFrameInfo, isIdr, isReference);

--- a/vk_video_encoder/src/vulkan_video_encoder.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder.cpp
@@ -153,9 +153,17 @@ VkResult VulkanVideoEncoderImpl::Initialize(VkVideoCodecOperationFlagBitsKHR vid
         }
     }
 
+    VkQueueFlags requestVideoComputeQueueMask = 0;
+    if (m_encoderConfig->enablePreprocessComputeFilter == VK_TRUE) {
+        requestVideoComputeQueueMask = VK_QUEUE_COMPUTE_BIT;
+    }
+
     // No display presentation and no decoder - just the encoder
     result = m_vkDevCtxt.InitPhysicalDevice(m_encoderConfig->deviceId, m_encoderConfig->GetDeviceUUID(),
-                                            (requestVideoDecodeQueueMask | requestVideoEncodeQueueMask | VK_QUEUE_TRANSFER_BIT),
+                                            ( requestVideoComputeQueueMask |
+                                              requestVideoDecodeQueueMask  |
+                                              requestVideoEncodeQueueMask  |
+                                              VK_QUEUE_TRANSFER_BIT),
                                             nullptr,
                                             requestVideoDecodeQueueMask,
                                             (VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR |
@@ -196,7 +204,8 @@ VkResult VulkanVideoEncoderImpl::Initialize(VkVideoCodecOperationFlagBitsKHR vid
                                             ((m_vkDevCtxt.GetVideoEncodeQueueFlag() & VK_QUEUE_TRANSFER_BIT) == 0), //  createTransferQueue
                                             false, // createGraphicsQueue
                                             false, // createDisplayQueue
-                                            (m_encoderConfig->selectVideoWithComputeQueue == 1)  // createComputeQueue
+                                            ((m_encoderConfig->selectVideoWithComputeQueue == 1) ||  // createComputeQueue
+                                             (m_encoderConfig->enablePreprocessComputeFilter == VK_TRUE))
                                           );
     if (result != VK_SUCCESS) {
 


### PR DESCRIPTION
Optimize the QpMap to use inlined command buffer transfer operations or direct handling of the images.
Add a compute filter as a preprocessor for the encoder to do last row and last column replication, color conversion, and scalling.