### PR TITLE
Revert "decode: use discrete views with image arrays"

### DIFF
--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -273,7 +273,7 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
     if(!(videoCapabilities.flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR)) {
         // The implementation does not support individual images for DPB and so must use arrays
         m_useImageArray = VK_TRUE;
-        m_useImageViewArray = VK_FALSE;
+        m_useImageViewArray = VK_TRUE;
     }
 
     if (m_enableDecodeComputeFilter) {


### PR DESCRIPTION
This reverts commit 78ca6884df51335cfd1613ecc50997ec28cda924.

This commit breaks all the test cases in fluster.

cc @zlatinski 