### PR TITLE
Only show warning when testing in verbose mode

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -472,7 +472,9 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
             enableQpMap = true;
         } else if (args[i] == "--testOutOfOrderRecording") {
             // Testing only - don't use this feature for production!
-            fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
+            if (verbose) {
+                fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
+            }
             enableOutOfOrderRecording = true;
         } else {
             argcount++;


### PR DESCRIPTION
The warning was printed many times while testing with the Vulkan CTS. Since --testOutOfOrderRecording is being passed, it's obvious that the intention is to use it "for testing", therefore the warning is fairly intrusive.