### PR TITLE
VulkanPerDrawContext::RecordCommandBuffer: use member vars

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -499,8 +499,6 @@ VkResult VulkanFrame<FrameDataType>::DrawFrame( int32_t            renderIndex,
                                          pPerDrawContext->frameBuffer.GetFbImage(),
                                          pPerDrawContext->frameBuffer.GetFrameBuffer(), &m_scissor,
                                          pPerDrawContext->gfxPipeline.getPipeline(),
-                                         pPerDrawContext->descriptorSetLayoutBinding,
-                                         pPerDrawContext->samplerYcbcrConversion,
                                          m_videoRenderer->m_vertexBuffer);
 
     if (dumpDebug) {

--- a/common/libs/VkCodecUtils/VulkanVideoUtils.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoUtils.cpp
@@ -670,8 +670,6 @@ VkResult VulkanPerDrawContext::RecordCommandBuffer(VkCommandBuffer cmdBuffer,
                                                    int32_t displayWidth, int32_t displayHeight,
                                                    VkImage displayImage, VkFramebuffer framebuffer, VkRect2D* pRenderArea,
                                                    VkPipeline pipeline,
-                                                   const VulkanDescriptorSetLayout& descriptorSetLayoutBinding,
-                                                   const VulkanSamplerYcbcrConversion& samplerYcbcrConversion,
                                                    const VulkanVertexBuffer& vertexBuffer)
 {
 

--- a/common/libs/VkCodecUtils/VulkanVideoUtils.h
+++ b/common/libs/VkCodecUtils/VulkanVideoUtils.h
@@ -658,8 +658,6 @@ public:
                                  int32_t displayWidth, int32_t displayHeight,
                                  VkImage displayImage, VkFramebuffer framebuffer, VkRect2D* pRenderArea,
                                  VkPipeline pipeline,
-                                 const VulkanDescriptorSetLayout& descriptorSetLayoutBinding,
-                                 const VulkanSamplerYcbcrConversion& samplerYcbcrConversion,
                                  const VulkanVertexBuffer& vertexBuffer);
 
     const VulkanDeviceContext* m_vkDevCtx;


### PR DESCRIPTION
RecordCommandBuffer should use its own member values instead of passing it through its API.

Avoid vars shadowing detected by CTS

Fixes #19 