### PR TITLE
Add missing copy of input data from file to memory for YUV444P

### DIFF
--- a/common/libs/VkCodecUtils/YCbCrConvUtilsCpu.h
+++ b/common/libs/VkCodecUtils/YCbCrConvUtilsCpu.h
@@ -240,6 +240,51 @@ public:
 
         return 0;
     }
+
+    static int I444ToP444(const planeType* src_y,
+                         int src_stride_y,
+                         const planeType* src_u,
+                         int src_stride_u,
+                         const planeType* src_v,
+                         int src_stride_v,
+                         planeType* dst_y,
+                         int dst_stride_y,
+                         planeType* dst_uv,
+                         int dst_stride_uv,
+                         int width,
+                         int height,
+                         int shiftBits = 0) {
+        if (!src_y || !src_u || !src_v || !dst_y || !dst_uv || width <= 0 || height == 0) {
+            return -1;
+        }
+
+        // Convert strides from bytes to elements
+        src_stride_y /= (int)sizeof(planeType);
+        dst_stride_y /= (int)sizeof(planeType);
+        src_stride_u /= (int)sizeof(planeType);
+        src_stride_v /= (int)sizeof(planeType);
+        dst_stride_uv /= (int)sizeof(planeType);
+
+        // Handle negative height (image inversion)
+        if (height < 0) {
+            height = -height;
+            src_y = src_y + (height - 1) * src_stride_y;
+            src_u = src_u + (height - 1) * src_stride_u;
+            src_v = src_v + (height - 1) * src_stride_v;
+            src_stride_y = -src_stride_y;
+            src_stride_u = -src_stride_u;
+            src_stride_v = -src_stride_v;
+        }
+
+        // Copy Y plane at full resolution
+        CopyPlane(src_y, src_stride_y, dst_y, dst_stride_y, width, height, shiftBits);
+
+        // Merge U and V planes at full resolution
+        MergeUVPlane(src_u, src_stride_u, src_v, src_stride_v, dst_uv, dst_stride_uv,
+                     width, height, shiftBits);
+
+        return 0;
+    }
 };
 
 #endif /* _VKCODECUTILS_YCBCRCONVUTILSCPU_H_ */

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -393,13 +393,23 @@ beach:
 
     uint32_t GetFrameCount(uint32_t width, uint32_t height, uint8_t bpp, VkVideoChromaSubsamplingFlagBitsKHR chromaSubsampling) {
         uint8_t nBytes = (uint8_t)(bpp + 7) / 8;
-        double samplingFactor = 1.5;
+        double samplingFactor = 1.5; // Default for 420
         switch (chromaSubsampling)
         {
+        case VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR:
+            samplingFactor = 1.0; // Only Y component
+            break;
         case VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR:
-            samplingFactor = 1.5;
+            samplingFactor = 1.5; // Y + 1/4 U + 1/4 V = 1.5
+            break;
+        case VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR:
+            samplingFactor = 2.0; // Y + 1/2 U + 1/2 V = 2.0
+            break;
+        case VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR:
+            samplingFactor = 3.0; // Full Y + full U + full V = 3.0
             break;
         default:
+            assert(!"Unknown chroma subsampling");
             break;
         }
         uint32_t frameSize = (uint32_t)(width * height * nBytes * samplingFactor);
@@ -928,6 +938,9 @@ public:
         if (!input.VerifyInputs()) {
             return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
         }
+
+        // Copy chroma subsampling from input to encoder config
+        encodeChromaSubsampling = input.chromaSubsampling;
 
         if ((encodeWidth == 0) || (encodeWidth > input.width)) {
             encodeWidth = input.width;


### PR DESCRIPTION
Also add support frame count calculations for YUV444P and YUV422P

Backport from https://github.com/nvpro-samples/vk_video_samples/pull/129