### PR TITLE
DecoderConfig: y4m should be off by default

### DIFF
--- a/common/libs/VkCodecUtils/DecoderConfig.h
+++ b/common/libs/VkCodecUtils/DecoderConfig.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <functional>
 #include <algorithm>
-#include <iomanip> 
+#include <iomanip>
 #include <sstream>
 #include "vulkan_interfaces.h"
 
@@ -75,14 +75,14 @@ struct DecoderConfig {
         enableHwLoadBalancing = false;
         selectVideoWithComputeQueue = false;
         enableVideoEncoder = false;
-        outputy4m = true; // by default, use Y4M
+        outputy4m = false;
         outputcrcPerFrame = false;
         outputcrc = false;
         crcOutputFileName.clear();
     }
 
     using ProgramArgs = std::vector<ArgSpec>;
-    static bool showHelp(const char ** argv, const ProgramArgs &spec) { 
+    static bool showHelp(const char ** argv, const ProgramArgs &spec) {
         std::cout << argv[0] << std::endl;
         for ( auto& flag : spec ) {
             std::stringstream ss;
@@ -349,7 +349,7 @@ struct DecoderConfig {
                     std::cerr << "Missing arguments for \"" << argv[i] << "\"" << std::endl;
                     exit(EXIT_FAILURE);
                 }
-                disableValueCheck = true; 
+                disableValueCheck = true;
                 i++;
             }
 


### PR DESCRIPTION
As there is a flag to enable y4m in the decoder config, the default value should be false and enabled by the flag on demand.