### PR TITLE
DecoderConfig: enable stream demuxing

### DIFF
--- a/common/libs/VkCodecUtils/DecoderConfig.h
+++ b/common/libs/VkCodecUtils/DecoderConfig.h
@@ -69,7 +69,7 @@ struct DecoderConfig {
         forceParserType = VK_VIDEO_CODEC_OPERATION_NONE_KHR;
         decoderQueueSize = 5;
         enablePostProcessFilter = -1,
-        enableStreamDemuxing = false;
+        enableStreamDemuxing = true;
         deviceId = (uint32_t)-1;
         directMode = false;
         enableHwLoadBalancing = false;
@@ -110,11 +110,6 @@ struct DecoderConfig {
                     int rtn = showHelp(argv, a);
                     exit(EXIT_SUCCESS);
                     return rtn;
-                }},
-            {"--enableStrDemux", nullptr, 0, "Enable stream demuxing",
-                [this](const char **, const ProgramArgs &a) {
-                    enableStreamDemuxing = true;
-                    return true;
                 }},
             {"--disableStrDemux", nullptr, 0, "Disable stream demuxing",
                 [this](const char **, const ProgramArgs &a) {

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -129,7 +129,7 @@ int main(int argc, const char **argv) {
         VkSharedBaseObj<VideoStreamDemuxer> videoStreamDemuxer;
         result = VideoStreamDemuxer::Create(decoderConfig.videoFileName.c_str(),
                                             decoderConfig.forceParserType,
-                                            (decoderConfig.enableStreamDemuxing == 1),
+                                            decoderConfig.enableStreamDemuxing,
                                             decoderConfig.initialWidth,
                                             decoderConfig.initialHeight,
                                             decoderConfig.initialBitdepth,
@@ -207,7 +207,7 @@ int main(int argc, const char **argv) {
         VkSharedBaseObj<VideoStreamDemuxer> videoStreamDemuxer;
         result = VideoStreamDemuxer::Create(decoderConfig.videoFileName.c_str(),
                                             decoderConfig.forceParserType,
-                                            (decoderConfig.enableStreamDemuxing == 1),
+                                            decoderConfig.enableStreamDemuxing,
                                             decoderConfig.initialWidth,
                                             decoderConfig.initialHeight,
                                             decoderConfig.initialBitdepth,

--- a/vk_video_decoder/test/vulkan-video-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-dec/Main.cpp
@@ -141,7 +141,7 @@ int main(int argc, const char** argv)
         VkSharedBaseObj<VideoStreamDemuxer> videoStreamDemuxer;
         result = VideoStreamDemuxer::Create(decoderConfig.videoFileName.c_str(),
                                             decoderConfig.forceParserType,
-                                            (decoderConfig.enableStreamDemuxing == 1),
+                                            decoderConfig.enableStreamDemuxing,
                                             decoderConfig.initialWidth,
                                             decoderConfig.initialHeight,
                                             decoderConfig.initialBitdepth,
@@ -222,7 +222,7 @@ int main(int argc, const char** argv)
         VkSharedBaseObj<VideoStreamDemuxer> videoStreamDemuxer;
         result = VideoStreamDemuxer::Create(decoderConfig.videoFileName.c_str(),
                                             decoderConfig.forceParserType,
-                                            (decoderConfig.enableStreamDemuxing == 1),
+                                            decoderConfig.enableStreamDemuxing,
                                             decoderConfig.initialWidth,
                                             decoderConfig.initialHeight,
                                             decoderConfig.initialBitdepth,

--- a/vk_video_decoder/test/vulkan-video-simple-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-simple-dec/Main.cpp
@@ -124,7 +124,7 @@ int main(int argc, const char** argv)
     VkSharedBaseObj<VideoStreamDemuxer> videoStreamDemuxer;
     VkResult result = VideoStreamDemuxer::Create(decoderConfig.videoFileName.c_str(),
                                                  decoderConfig.forceParserType,
-                                                 (decoderConfig.enableStreamDemuxing == 1),
+                                                 decoderConfig.enableStreamDemuxing,
                                                  decoderConfig.initialWidth,
                                                  decoderConfig.initialHeight,
                                                  decoderConfig.initialBitdepth,


### PR DESCRIPTION
By default, if FFmpeg is present, the stream
demuxer should be enabled.