### PR TITLE
Fix YUV filter push constant size

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
@@ -149,7 +149,7 @@ VkResult VulkanFilterYuvCompute::InitDescriptorSetLayout(uint32_t maxNumFrames)
     VkPushConstantRange pushConstantRange = {};
     pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT; // Stage the push constant is for
     pushConstantRange.offset = 0;
-    pushConstantRange.size = 2 * sizeof(uint32_t); // Size of the push constant - source and destination image layers
+    pushConstantRange.size = 6 * sizeof(uint32_t); // Size of the push constant - source and destination image layers + 2 * ivec2
 
     return m_descriptorSetLayout.CreateDescriptorSet(m_vkDevCtx,
                                                      setLayoutBindings,


### PR DESCRIPTION
The push constants size in the descriptor is too small compared to the size in the shader.