### PR TITLE
VulkanImage: set the image create format

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -186,7 +186,7 @@ int VulkanFrame<FrameDataType>::AttachSwapchain(const Shell& sh)
     const uint32_t queueFamilyIndices = m_videoRenderer->m_vkDevCtx->GetGfxQueueFamilyIdx();
     imageCreateInfo.pQueueFamilyIndices = &queueFamilyIndices;
     imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    imageCreateInfo.flags = 0;
+    imageCreateInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     m_videoRenderer->m_testFrameImage.CreateImage(m_videoRenderer->m_vkDevCtx, &imageCreateInfo,
                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
                                                   1 /* ColorPatternColorBars */);

--- a/common/libs/VkCodecUtils/VulkanVideoUtils.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoUtils.cpp
@@ -205,12 +205,6 @@ int32_t ImageObject::GetImageSubresourceAndLayout(VkSubresourceLayout layouts[3]
 
 VkResult ImageObject::FillImageWithPattern(int pattern)
 {
-    const VkImageSubresource subres = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
-
-    VkSubresourceLayout layout;
-
-    m_vkDevCtx->GetImageSubresourceLayout(*m_vkDevCtx, image, &subres, &layout);
-
     uint8_t* mappedHostPtr = MapHostPtr();
     VkDeviceMemory devMemory = m_imageResource->GetDeviceMemory();
 
@@ -228,6 +222,10 @@ VkResult ImageObject::FillImageWithPattern(int pattern)
         VkFillYuv vkFillYuv;
         vkFillYuv.fillVkImage(m_vkDevCtx, image, &imageData, devMemory, mappedHostPtr, &ycbcrConversionInfo);
     } else {
+        const VkImageSubresource subres = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
+        VkSubresourceLayout layout;
+        m_vkDevCtx->GetImageSubresourceLayout(*m_vkDevCtx, image, &subres, &layout);
+
         generateColorPatternRgba8888((ColorPattern)pattern, (uint8_t *)mappedHostPtr,
                                  imageWidth, imageHeight,
                                  (uint32_t)layout.rowPitch);

--- a/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
+++ b/vk_video_decoder/libs/VulkanVideoFrameBuffer/VulkanVideoFrameBuffer.cpp
@@ -974,6 +974,7 @@ int32_t NvPerFrameDecodeImageSet::init(const VulkanDeviceContext* vkDevCtx,
         m_imageSpecs[imageTypeIdx].createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
         m_imageSpecs[imageTypeIdx].createInfo.pNext = m_videoProfile.GetProfileListInfo();
         m_imageSpecs[imageTypeIdx].createInfo.queueFamilyIndexCount = 1;
+        m_imageSpecs[imageTypeIdx].createInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
         m_imageSpecs[imageTypeIdx].createInfo.pQueueFamilyIndices = &m_queueFamilyIndex;
         m_imageSpecs[imageTypeIdx].usesImageViewArray = usesImageViewArray;
         m_imageSpecs[imageTypeIdx].usesImageArray = usesImageArray;


### PR DESCRIPTION
ANV driver needs the flag VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT

Separate PR following the discussion of https://github.com/KhronosGroup/Vulkan-Video-Samples/pull/34#discussion_r2093136540