### PR TITLE
VulkanVideoSession: Increase MAX_BOUND_MEMORY

### DIFF
--- a/common/libs/VkCodecUtils/VulkanVideoSession.h
+++ b/common/libs/VkCodecUtils/VulkanVideoSession.h
@@ -22,7 +22,7 @@
 
 class VulkanVideoSession : public VkVideoRefCountBase
 {
-    enum { MAX_BOUND_MEMORY = 8 };
+    enum { MAX_BOUND_MEMORY = 40 };
 public:
     static VkResult Create(const VulkanDeviceContext* vkDevCtx,
                            VkVideoSessionCreateFlagsKHR sessionCreateFlags,


### PR DESCRIPTION
AV1 decoding on ANV requires almost 40 video memories.

H265 encoding requires at least 10 video memories.

See https://github.com/KhronosGroup/VK-GL-CTS/commit/28d433ac8ef5fdb437a9851c8f4a1159269f85fe