### PR TITLE
VulkanDeviceContext: initialize transfer queue

### DIFF
--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -585,6 +585,13 @@ VkResult VulkanDeviceContext::InitPhysicalDevice(int32_t deviceId, const uint8_t
                 if (dumpQueues) std::cout << "\t Found compute queue family " <<  i << " with " << queue.queueFamilyProperties.queueCount << " max num of queues." << std::endl;
             }
 
+            if ((requestQueueTypes & VK_QUEUE_TRANSFER_BIT) && (transferQueueFamily < 0) &&
+                    (queueFamilyFlags & VK_QUEUE_TRANSFER_BIT)) {
+                transferQueueFamily = i;
+                foundQueueTypes |= queueFamilyFlags;
+                if (dumpQueues) std::cout << "\t Found transfer queue family " <<  i << " with " << queue.queueFamilyProperties.queueCount << " max num of queues." << std::endl;
+            }
+
             // present queue must support the surface
             if ((pWsiDisplay != nullptr) &&
                     (presentQueueFamily < 0) && pWsiDisplay->PhysDeviceCanPresent(physicalDevice, i)) {

--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -809,7 +809,7 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
         GetDeviceQueue(m_device, GetPresentQueueFamilyIdx(), 0, &m_presentQueue);
     }
     if (createTransferQueue) {
-        GetDeviceQueue(m_device, GetTransferQueueFamilyIdx(), 0, &m_trasferQueue);
+        GetDeviceQueue(m_device, GetTransferQueueFamilyIdx(), 0, &m_transferQueue);
     }
     if (numDecodeQueues) {
         assert(GetVideoDecodeQueueFamilyIdx() != -1);
@@ -859,7 +859,7 @@ VulkanDeviceContext::VulkanDeviceContext()
     , m_device()
     , m_gfxQueue()
     , m_computeQueue()
-    , m_trasferQueue()
+    , m_transferQueue()
     , m_presentQueue()
     , m_debugReport()
     , m_reqInstanceLayers()

--- a/common/libs/VkCodecUtils/VulkanDeviceContext.h
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.h
@@ -71,7 +71,7 @@ public:
     int32_t GetPresentQueueFamilyIdx() const { return m_presentQueueFamily; }
     VkQueue GetPresentQueue() const { return m_presentQueue; }
     int32_t GetTransferQueueFamilyIdx() const { return m_transferQueueFamily; }
-    VkQueue GetTransferQueue() const { return m_trasferQueue; }
+    VkQueue GetTransferQueue() const { return m_transferQueue; }
     int32_t GetVideoDecodeQueueFamilyIdx() const { return m_videoDecodeQueueFamily; }
     int32_t GetVideoDecodeDefaultQueueIndex() const { return m_videoDecodeDefaultQueueIndex; }
     int32_t GetVideoDecodeNumQueues() const { return m_videoDecodeNumQueues; }
@@ -108,7 +108,7 @@ public:
                 m_mutex = &devCtx->m_computeQueueMutex;
                 break;
             case TRANSFER:
-                m_queue = &devCtx->m_trasferQueue;
+                m_queue = &devCtx->m_transferQueue;
                 m_mutex = &devCtx->m_transferQueueMutex;
                 break;
             case DECODE:
@@ -310,7 +310,7 @@ private:
     VkDevice                m_device;
     VkQueue                 m_gfxQueue;
     VkQueue                 m_computeQueue;
-    VkQueue                 m_trasferQueue;
+    VkQueue                 m_transferQueue;
     VkQueue                 m_presentQueue;
     std::vector<VkQueue>    m_videoDecodeQueues;
     std::vector<VkQueue>    m_videoEncodeQueues;


### PR DESCRIPTION
As the transfer queue can be different from the decode queue, this queue must be detected and associated to a valid number.

Fix typo in the name of the m_transferQueue member var.