### PR TITLE
H265: Initialize profile_idc with INVALID value

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -430,6 +430,7 @@ void EncoderConfigH265::InitializeSpsRefPicSet(SpsH265 *pSps)
 StdVideoH265ProfileTierLevel EncoderConfigH265::GetLevelTier()
 {
     StdVideoH265ProfileTierLevel profileTierLevel{};
+    profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_INVALID;
     profileTierLevel.general_level_idc = STD_VIDEO_H265_LEVEL_IDC_INVALID;
     uint32_t levelIdx = 0;
     for (; levelIdx < levelLimitsTblSize; levelIdx++) {


### PR DESCRIPTION
Fixing #62 