### PR TITLE
vp9 compilation fix

### DIFF
--- a/cmake/LinuxSettings.cmake
+++ b/cmake/LinuxSettings.cmake
@@ -84,7 +84,7 @@ endif()
 
 # Compiler flags for GCC/Clang
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
+    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wcast-qual")
     set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
 
     # Warning about implicit fallthrough in switch blocks


### PR DESCRIPTION
  - [VulkanVP9Decoder: Fix 32b conversion errors](https://github.com/KhronosGroup/Vulkan-Video-Samples/commit/4248182a870fcc273e8fef03a1f86b15253b0b6f)
  - [CMake: Add cast-qual to the cmake settings](https://github.com/KhronosGroup/Vulkan-Video-Samples/commit/bd9510b622d1f61ecd1e4925287503a8afa57049)

Reviewed in https://github.com/nvpro-samples/vk_video_samples/pull/150