### PR TITLE
EncoderConfig: set default preferredGopFrameCount

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -251,7 +251,8 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
         rateControlMode = qualityLevelProperties.preferredRateControlMode;
     }
     if (gopStructure.GetGopFrameCount() == ZERO_GOP_FRAME_COUNT) {
-        gopStructure.SetGopFrameCount(av1QualityLevelProperties.preferredGopFrameCount);
+        gopStructure.SetGopFrameCount(av1QualityLevelProperties.preferredGopFrameCount ?
+            av1QualityLevelProperties.preferredGopFrameCount : UINT8_MAX);
     }
     if (gopStructure.GetIdrPeriod() == ZERO_GOP_IDR_PERIOD) {
         gopStructure.SetIdrPeriod(av1QualityLevelProperties.preferredKeyFramePeriod);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -391,7 +391,8 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
         rateControlMode = qualityLevelProperties.preferredRateControlMode;
     }
     if (gopStructure.GetGopFrameCount() == ZERO_GOP_FRAME_COUNT) {
-        gopStructure.SetGopFrameCount(h264QualityLevelProperties.preferredGopFrameCount);
+        gopStructure.SetGopFrameCount(h264QualityLevelProperties.preferredGopFrameCount ?
+            h264QualityLevelProperties.preferredGopFrameCount : UINT8_MAX);
     }
     if (gopStructure.GetIdrPeriod() == ZERO_GOP_IDR_PERIOD) {
         gopStructure.SetIdrPeriod(h264QualityLevelProperties.preferredIdrPeriod);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -125,7 +125,8 @@ VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vk
         rateControlMode = qualityLevelProperties.preferredRateControlMode;
     }
     if (gopStructure.GetGopFrameCount() == ZERO_GOP_FRAME_COUNT) {
-        gopStructure.SetGopFrameCount(h265QualityLevelProperties.preferredGopFrameCount);
+        gopStructure.SetGopFrameCount(h265QualityLevelProperties.preferredGopFrameCount ?
+            h265QualityLevelProperties.preferredGopFrameCount : UINT8_MAX);
     }
     if (gopStructure.GetIdrPeriod() == ZERO_GOP_IDR_PERIOD) {
         gopStructure.SetIdrPeriod(h265QualityLevelProperties.preferredIdrPeriod);


### PR DESCRIPTION
As some implementations (mesa) do report preferredGopFrameCount to 0 and seen that the minimum value is always chosen, use UINT8_MAX as a default value if its zero.

Fixing a divide by zero issue in VkVideoGopStructure.h+176

Fixing #54 