### PR TITLE
Revert "CMake: Add cast-qual to the cmake settings"

### DIFF
--- a/cmake/LinuxSettings.cmake
+++ b/cmake/LinuxSettings.cmake
@@ -84,7 +84,7 @@ endif()
 
 # Compiler flags for GCC/Clang
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wcast-qual")
+    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
     set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
 
     # Warning about implicit fallthrough in switch blocks


### PR DESCRIPTION
This reverts commit 2409496dd82c9ed79501a2d1af32624874b1b19e.

This commit introduces a regression with warnings due to missing patches such as:

 - 88875e4 common: Code compilation fixes
 - 16607fe encoder: Deal with the Vulkan chained stuctures

`common: Code compilation fixes` needs #53 first to be backported properly