### PR TITLE
encoder: fix type conversion from double to uint32_t

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -152,7 +152,7 @@ struct EncoderConfigAV1 : public EncoderConfig {
             lTier = 0;
         }
 
-        uint32_t minCRBase = lTier ? levelLimits[lLevel].highCR : levelLimits[lLevel].mainCR;
+        double minCRBase = lTier ? levelLimits[lLevel].highCR : levelLimits[lLevel].mainCR;
         double speedAdj = decodeRate / levelLimits[lLevel].maxDisplayRate;
 
         return std::max(minCRBase * speedAdj, 0.8);


### PR DESCRIPTION
The following conversion might lead to precision loss, use a double instead of uin32_t to keep the precision.