### PR TITLE
cmake: Fix the Vulkan headers HEAD pulled-in by cmake

### DIFF
--- a/cmake/FindVulkanSDK.cmake
+++ b/cmake/FindVulkanSDK.cmake
@@ -81,7 +81,7 @@ MACRO(FIND_VULKAN_HEADERS VK_MINIMUM_MAJOR_VERSION VK_MINIMUM_MINOR_VERSION VK_M
         FetchContent_Declare(
             vulkan-headers
             GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers.git
-            GIT_TAG main
+            GIT_TAG v${VK_MINIMUM_MAJOR_VERSION}.${VK_MINIMUM_MINOR_VERSION}.${VK_MINIMUM_PATCH_VERSION}
         )
         FetchContent_MakeAvailable(vulkan-headers)
 
@@ -110,7 +110,7 @@ MACRO(FIND_VULKAN_SDK minimum_major_version minimum_minor_version minimum_patch_
         FetchContent_Declare(
             vulkan-loader
             GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Loader.git
-            GIT_TAG main
+            GIT_TAG v${minimum_major_version}.${minimum_minor_version}.${minimum_patch_version}
         )
         FetchContent_MakeAvailable(vulkan-loader)
         set(VULKAN_LOADER_LIBRARY_DIR "${CMAKE_BINARY_DIR}/_deps/vulkan-loader-build/loader")


### PR DESCRIPTION
It is using `main` branch, which is a moving target and could break the build unexpectedly.
