### PR TITLE
codec: fix signed/unsigned comparison warnings

### DIFF
--- a/vk_video_decoder/include/vkvideo_parser/VulkanVideoParserParams.h
+++ b/vk_video_decoder/include/vkvideo_parser/VulkanVideoParserParams.h
@@ -53,7 +53,7 @@ struct VkParserPerFrameDecodeParameters {
     VkSharedBaseObj<VulkanBitstreamBuffer> bitstreamData; // bitstream data for this picture (slice-layer)
     VkVideoDecodeInfoKHR decodeFrameInfo;
     VkVideoPictureResourceInfoKHR dpbSetupPictureResource;
-    int32_t numGopReferenceSlots;
+    uint32_t numGopReferenceSlots;
     int8_t pGopReferenceImagesIndexes[MAX_DPB_REF_AND_SETUP_SLOTS];
     VkVideoPictureResourceInfoKHR pictureResources[MAX_DPB_REF_AND_SETUP_SLOTS];
 };

--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -79,7 +79,7 @@ VulkanAV1Decoder::VulkanAV1Decoder(VkVideoCodecOperationFlagBitsKHR std, bool an
     , m_showableFrame{}
 
 {
-    for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
         ref_frame_id[i] = -1;
 		pic_idx[i] = -1;
     }
@@ -317,7 +317,7 @@ bool VulkanAV1Decoder::BeginPicture(VkParserPictureData* pnvpd)
     av1->setupSlotInfo.flags.segmentation_enabled = m_PicData.std_info.flags.segmentation_enabled;
 
     // Referenced frame information
-    for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
         vkPicBuffBase *pb = reinterpret_cast<vkPicBuffBase *>(m_pBuffers[i].buffer);
         av1->pic_idx[i] = pb ? pb->m_picIdx : -1;
         av1->dpbSlotInfos[i].flags.disable_frame_end_update_cdf = m_pBuffers[i].disable_frame_end_update_cdf;
@@ -332,14 +332,14 @@ bool VulkanAV1Decoder::BeginPicture(VkParserPictureData* pnvpd)
 
     // TODO: It's weird that the intra frame motion isn't tracked by the parser.
     // Need an affine translation test case to properly check this.
-    for (int i = 1; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 1; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
         av1->globalMotion.GmType[i] = global_motions[i-1].wmtype;
         for (int j = 0; j <= 5; j++) {
             av1->globalMotion.gm_params[i][j] = global_motions[i-1].wmmat[j];
         }
     }
 
-    for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
         av1->ref_frame_idx[i] = ref_frame_idx[i];
     }
 
@@ -946,7 +946,8 @@ int VulkanAV1Decoder::SetupFrameSizeWithRefs()
 	StdVideoDecodeAV1PictureInfo *const pStd = &m_PicData.std_info;
 
     uint32_t tmp;
-    int32_t found, i;
+    int32_t found;
+    uint32_t i;
 
     found = 0;
 
@@ -1068,28 +1069,28 @@ bool VulkanAV1Decoder::ReadFilmGrainParams()
         pFilmGrain->grain_scaling_minus_8 = u(2);
         pFilmGrain->ar_coeff_lag = u(2);
 
-        int numPosLuma = 2 * pFilmGrain->ar_coeff_lag * (pFilmGrain->ar_coeff_lag + 1);
+        uint32_t numPosLuma = 2 * pFilmGrain->ar_coeff_lag * (pFilmGrain->ar_coeff_lag + 1);
 		assert(numPosLuma <= STD_VIDEO_AV1_MAX_NUM_POS_LUMA);
-        int numPosChroma = numPosLuma;
+        uint32_t numPosChroma = numPosLuma;
         if (pFilmGrain->num_y_points > 0) {
             ++numPosChroma;
         }
 		assert(numPosChroma <= STD_VIDEO_AV1_MAX_NUM_POS_CHROMA);
 
         if (pFilmGrain->num_y_points) {
-            for (int i = 0; i < numPosLuma; i++) {
+            for (uint32_t i = 0; i < numPosLuma; i++) {
                 pFilmGrain->ar_coeffs_y_plus_128[i] = u(8);
             }
         }
 
         if (pFilmGrain->num_cb_points || pFilmGrain->flags.chroma_scaling_from_luma) {
-            for (int i = 0; i < numPosChroma; i++) {
+            for (uint32_t i = 0; i < numPosChroma; i++) {
                 pFilmGrain->ar_coeffs_cb_plus_128[i] = u(8);
             }
         }
 
         if (pFilmGrain->num_cr_points || pFilmGrain->flags.chroma_scaling_from_luma) {
-            for (int i = 0; i < numPosChroma; i++) {
+            for (uint32_t i = 0; i < numPosChroma; i++) {
                 pFilmGrain->ar_coeffs_cr_plus_128[i] = u(8);
             }
         }
@@ -1374,9 +1375,9 @@ void VulkanAV1Decoder::DecodeSegmentationData()
     }
 
     if (flags->segmentation_update_data) {
-        for (int i = 0; i < STD_VIDEO_AV1_MAX_SEGMENTS; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_MAX_SEGMENTS; i++) {
 		    pSegmentation->FeatureEnabled[i] = 0;
-            for (int j = 0; j < STD_VIDEO_AV1_SEG_LVL_MAX; j++) {
+            for (uint32_t j = 0; j < STD_VIDEO_AV1_SEG_LVL_MAX; j++) {
                 int feature_value = 0;
 				int enabled = u(1);
 				pSegmentation->FeatureEnabled[i] |= enabled << j;
@@ -1445,13 +1446,13 @@ void VulkanAV1Decoder::DecodeLoopFilterdata()
         lf_mode_ref_delta_update = u(1);
         pLoopFilter->flags.loop_filter_delta_update = lf_mode_ref_delta_update;
         if (lf_mode_ref_delta_update) {
-            for (int i = 0; i < STD_VIDEO_AV1_TOTAL_REFS_PER_FRAME; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_AV1_TOTAL_REFS_PER_FRAME; i++) {
                 if (u(1)) {
                     pLoopFilter->loop_filter_ref_deltas[i] = ReadSignedBits(6);
                 }
             }
 
-            for (int i = 0; i < STD_VIDEO_AV1_LOOP_FILTER_ADJUSTMENTS; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_AV1_LOOP_FILTER_ADJUSTMENTS; i++) {
                 if (u(1)) {
                     pLoopFilter->loop_filter_mode_deltas[i] = ReadSignedBits(6);
                 }
@@ -1582,11 +1583,11 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     int Ref_OrderHint;
     int usedFrame[STD_VIDEO_AV1_NUM_REF_FRAMES];
     int hint;
-    for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
         ref_frame_idx[i] = -1;
     }
 
-    for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
         usedFrame[i] = 0;
     }
 
@@ -1595,7 +1596,7 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     usedFrame[last_frame_idx] = 1;
     usedFrame[gold_frame_idx] = 1;
 
-    for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
         Ref_OrderHint = RefOrderHint[i];
         shiftedOrderHints[i] = curFrameHint + GetRelativeDist1(Ref_OrderHint, pStd->OrderHint);
     }
@@ -1603,7 +1604,7 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     {//ALTREF_FRAME
         int ref = -1;
         int latestOrderHint = -1;
-        for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             hint = shiftedOrderHints[i];
             if (!usedFrame[i] &&
                 hint >= curFrameHint &&
@@ -1621,7 +1622,7 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     {//BWDREF_FRAME
         int ref = -1;
         int earliestOrderHint = -1;
-        for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             hint = shiftedOrderHints[i];
             if (!usedFrame[i] &&
                 hint >= curFrameHint &&
@@ -1639,7 +1640,7 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     {//ALTREF2_FRAME
         int ref = -1;
         int earliestOrderHint = -1;
-        for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             hint = shiftedOrderHints[i];
             if (!usedFrame[i] &&
                 hint >= curFrameHint &&
@@ -1662,12 +1663,12 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
 		STD_VIDEO_AV1_REFERENCE_NAME_ALTREF_FRAME
 	};
 
-    for (int j = 0; j < STD_VIDEO_AV1_REFS_PER_FRAME - 2; j++) {
+    for (uint32_t j = 0; j < STD_VIDEO_AV1_REFS_PER_FRAME - 2; j++) {
         int refFrame = Ref_Frame_List[j];
         if (ref_frame_idx[refFrame - STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME] < 0) {
             int ref = -1;
             int latestOrderHint = -1;
-            for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
                 hint = shiftedOrderHints[i];
                 if (!usedFrame[i] &&
                     hint < curFrameHint &&
@@ -1686,14 +1687,14 @@ void VulkanAV1Decoder::SetFrameRefs(int last_frame_idx, int gold_frame_idx)
     {
         int ref = -1;
         int earliestOrderHint = -1;
-        for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             hint = shiftedOrderHints[i];
             if (ref < 0 || hint < earliestOrderHint) {
                 ref = i;
                 earliestOrderHint = hint;
             }
         }
-        for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
             if (ref_frame_idx[i] < 0) {
                 ref_frame_idx[i] = ref;
             }
@@ -1717,7 +1718,7 @@ int VulkanAV1Decoder::IsSkipModeAllowed()
     // Identify the nearest forward and backward references.
     int ref0 = -1, ref1 = -1;
     int ref0_off = -1, ref1_off = -1;
-    for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
         int frame_idx = ref_frame_idx[i];
         if (frame_idx != -1) {
             int ref_frame_offset = RefOrderHint[frame_idx];
@@ -1746,7 +1747,7 @@ int VulkanAV1Decoder::IsSkipModeAllowed()
     } else if (ref0 != -1) {
         // == Forward prediction only ==
         // Identify the second nearest forward reference.
-        for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
             int frame_idx = ref_frame_idx[i];
             if (frame_idx != -1) {
                 int ref_frame_offset = RefOrderHint[frame_idx];
@@ -1864,7 +1865,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
 
 
     if (pStd->frame_type == STD_VIDEO_AV1_FRAME_TYPE_KEY && pic_info->showFrame) {
-        for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             RefValid[i] = 0;
             RefOrderHint[i] = 0;
         }
@@ -1899,7 +1900,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
 
     if (!sps->flags.reduced_still_picture_header) {
         if (sps->flags.frame_id_numbers_present_flag) {
-            int diff_len = delta_frame_id_length;
+            uint32_t diff_len = delta_frame_id_length;
             int prev_frame_id = 0;
             if (!(pStd->frame_type == STD_VIDEO_AV1_FRAME_TYPE_KEY && pic_info->showFrame)) {
                 prev_frame_id = pStd->current_frame_id;
@@ -1921,8 +1922,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
                 }
             }
             // Mark ref frames not valid for referencing
-            assert(diff_len >= 0);
-            for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
                 if (pStd->frame_type == STD_VIDEO_AV1_FRAME_TYPE_KEY && pic_info->showFrame) {
                     RefValid[i] = 0;
                 } else if (ref_frame_id[i] < 0) {
@@ -1982,7 +1982,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
             pStd->refresh_frame_flags = (1 << STD_VIDEO_AV1_NUM_REF_FRAMES) - 1;
         }
 
-        for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
             ref_frame_idx[i] = 0;
         }
 
@@ -2002,11 +2002,11 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
 
     if (((!IsFrameIntra()) || pStd->refresh_frame_flags != 0xFF) &&
         pic_flags->error_resilient_mode && sps->flags.enable_order_hint) {
-        for (int buf_idx = 0; buf_idx < STD_VIDEO_AV1_NUM_REF_FRAMES; buf_idx++) {
+        for (uint32_t buf_idx = 0; buf_idx < STD_VIDEO_AV1_NUM_REF_FRAMES; buf_idx++) {
             // ref_order_hint[i]
             int offset = u(sps->order_hint_bits_minus_1 + 1);
             // assert(buf_idx < FRAME_BUFFERS);
-            if (buf_idx == -1 || offset != RefOrderHint[buf_idx]) {
+            if (offset != RefOrderHint[buf_idx]) {
                 //RefValid[buf_idx] = 0;
                 //RefOrderHint[buf_idx] = frame_offset;
                 assert(0);
@@ -2045,7 +2045,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
                 SetFrameRefs(lst_ref, gld_ref);
             }
 
-            for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
                 if (!pic_flags->frame_refs_short_signaling) {
                     int ref_frame_index = u(REF_FRAMES_BITS);
                     ref_frame_idx[i] = ref_frame_index;
@@ -2057,7 +2057,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
                 }
 
                 if (sps->flags.frame_id_numbers_present_flag) {
-                    int diff_len = delta_frame_id_length;
+                    uint32_t diff_len = delta_frame_id_length;
                     int delta_frame_id_minus_1 = u(diff_len);
                     int ref_id = ((pStd->current_frame_id - (delta_frame_id_minus_1 + 1) +
                         (1 << frame_id_length)) % (1 << frame_id_length));
@@ -2099,7 +2099,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
         }
 
         // According to AV1 specification: "5.9.2. Uncompressed header syntax"
-        for (int i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_REFS_PER_FRAME; i++) {
             // Range check ref_frame_idx, RefOrderHint[] needs to be of size: BUFFER_POOL_MAX_SIZE.
             if ((ref_frame_idx[i] >= BUFFER_POOL_MAX_SIZE) && (ref_frame_idx[i] < 0)) {
                 assert(false);
@@ -2123,8 +2123,8 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
 
     if (sps->flags.frame_id_numbers_present_flag) {
         // Update reference frame id's
-        int tmp_flags = pStd->refresh_frame_flags;
-        for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        uint32_t tmp_flags = pStd->refresh_frame_flags;
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             if ((tmp_flags >> i) & 1) {
                 ref_frame_id[i] = pStd->current_frame_id;
                 RefValid[i] = 1;
@@ -2160,7 +2160,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
         }
     }
 
-    for (int i = 0; i < STD_VIDEO_AV1_MAX_SEGMENTS; ++i) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_MAX_SEGMENTS; ++i) {
         int qindex = pic_flags->segmentation_enabled && (pic_info->segmentation.FeatureEnabled[i] & 0)
             ? pic_info->segmentation.FeatureData[i][0] + pic_info->quantization.base_q_idx : pic_info->quantization.base_q_idx;
         qindex = CLAMP(qindex, 0, 255);
@@ -2171,7 +2171,7 @@ bool VulkanAV1Decoder::ParseObuFrameHeader()
 
     coded_lossless = lossless[0];
     if (pic_flags->segmentation_enabled) {
-        for (int i = 1; i < STD_VIDEO_AV1_MAX_SEGMENTS; i++) {
+        for (uint32_t i = 1; i < STD_VIDEO_AV1_MAX_SEGMENTS; i++) {
             coded_lossless &= lossless[i];
         }
     }

--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanVP9Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanVP9Decoder.cpp
@@ -415,7 +415,7 @@ bool VulkanVP9Decoder::ParseUncompressedHeader()
         pStdPicInfo->refresh_frame_flags = (1 << STD_VIDEO_VP9_NUM_REF_FRAMES) - 1;
         pPicData->FrameIsIntra = true;
 
-        for (int i = 0; i < STD_VIDEO_VP9_REFS_PER_FRAME; ++i) {
+        for (uint32_t i = 0; i < STD_VIDEO_VP9_REFS_PER_FRAME; ++i) {
             pPicData->ref_frame_idx[i] = 0;
         }
     } else { // non key frame
@@ -441,7 +441,7 @@ bool VulkanVP9Decoder::ParseUncompressedHeader()
             pStdPicInfo->refresh_frame_flags = u(STD_VIDEO_VP9_NUM_REF_FRAMES);
 
             pStdPicInfo->ref_frame_sign_bias_mask = 0;
-            for (int i = 0; i < STD_VIDEO_VP9_REFS_PER_FRAME; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_VP9_REFS_PER_FRAME; i++) {
                 pPicData->ref_frame_idx[i] = u(3);
                 pStdPicInfo->ref_frame_sign_bias_mask |= (u(1) << (STD_VIDEO_VP9_REFERENCE_NAME_LAST_FRAME + i));
             }
@@ -563,7 +563,7 @@ void VulkanVP9Decoder::ParseFrameAndRenderSizeWithRefs()
 
     bool found_ref = false;
 
-    for (int i = 0; i < STD_VIDEO_VP9_REFS_PER_FRAME; ++i) {
+    for (uint32_t i = 0; i < STD_VIDEO_VP9_REFS_PER_FRAME; ++i) {
         found_ref = u(1);
         if (found_ref) {
             VkPicIf* pRefPic = m_pBuffers[pPicData->ref_frame_idx[i]].buffer;
@@ -642,7 +642,7 @@ void VulkanVP9Decoder::ParseLoopFilterParams()
 
         if (pStdLoopFilter->flags.loop_filter_delta_update) {
 
-            for (int i = 0; i < STD_VIDEO_VP9_MAX_REF_FRAMES; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_VP9_MAX_REF_FRAMES; i++) {
                 uint8_t update_ref_delta = u(1);
                 pStdLoopFilter->update_ref_delta |= update_ref_delta << i;
                 if (update_ref_delta == 1) {
@@ -653,7 +653,7 @@ void VulkanVP9Decoder::ParseLoopFilterParams()
                 }
             }
 
-            for (int i = 0; i < STD_VIDEO_VP9_LOOP_FILTER_ADJUSTMENTS; i++) {
+            for (uint32_t i = 0; i < STD_VIDEO_VP9_LOOP_FILTER_ADJUSTMENTS; i++) {
                 uint8_t update_mode_delta = u( 1);
                 pStdLoopFilter->update_mode_delta |= update_mode_delta << i;
                 if (update_mode_delta) {
@@ -715,13 +715,13 @@ void VulkanVP9Decoder::ParseSegmentationParams()
 
     if (pSegment->flags.segmentation_update_map == 1) {
 
-        for (int i = 0; i < STD_VIDEO_VP9_MAX_SEGMENTATION_TREE_PROBS; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_VP9_MAX_SEGMENTATION_TREE_PROBS; i++) {
             uint8_t prob_coded = u(1);
             pSegment->segmentation_tree_probs[i] = (prob_coded == 1) ? u(8) : VP9_MAX_PRBABILITY;
         }
 
         pSegment->flags.segmentation_temporal_update = u(1);
-        for (int i = 0; i < STD_VIDEO_VP9_MAX_SEGMENTATION_PRED_PROB; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_VP9_MAX_SEGMENTATION_PRED_PROB; i++) {
             if (pSegment->flags.segmentation_temporal_update) {
                 uint8_t prob_coded = u(1);
                 pSegment->segmentation_pred_prob[i] = (prob_coded == 1) ? u(8) : VP9_MAX_PRBABILITY;
@@ -739,8 +739,8 @@ void VulkanVP9Decoder::ParseSegmentationParams()
         memset(pSegment->FeatureEnabled, 0, sizeof(pSegment->FeatureEnabled));
         memset(pSegment->FeatureData, 0, sizeof(pSegment->FeatureData));
 
-        for (int i = 0; i < STD_VIDEO_VP9_MAX_SEGMENTS; i++) {
-            for (int j = 0; j < STD_VIDEO_VP9_SEG_LVL_MAX; j++) {
+        for (uint32_t i = 0; i < STD_VIDEO_VP9_MAX_SEGMENTS; i++) {
+            for (uint32_t j = 0; j < STD_VIDEO_VP9_SEG_LVL_MAX; j++) {
                 uint8_t feature_enabled = u(1);
                 pSegment->FeatureEnabled[i] |= (feature_enabled << j);
 
@@ -900,7 +900,7 @@ bool VulkanVP9Decoder::BeginPicture(VkParserPictureData* pnvpd)
     pnvpd->chroma_format = pPicDataVP9->ChromaFormat;
 
     // Reference slots information
-    for (int i = 0; i < STD_VIDEO_VP9_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_VP9_NUM_REF_FRAMES; i++) {
         vkPicBuffBase* pb = reinterpret_cast<vkPicBuffBase*>(m_pBuffers[i].buffer);
         pPicDataVP9->pic_idx[i] = pb ? pb->m_picIdx : -1;
     }

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -899,11 +899,11 @@ int VkVideoDecoder::DecodePictureWithParameters(VkParserPerFrameDecodeParameters
                                                        pictureResourcesInfo,
                                                        VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR);
 
-        if (pCurrFrameDecParams->numGopReferenceSlots != dpbResourceIndex) {
+        if (dpbResourceIndex < 0 || pCurrFrameDecParams->numGopReferenceSlots != static_cast<uint32_t>(dpbResourceIndex)) {
             assert(!"GetImageResourcesByIndex has failed");
         }
 
-        for (int32_t resId = 0; resId < pCurrFrameDecParams->numGopReferenceSlots; resId++) {
+        for (uint32_t resId = 0; resId < pCurrFrameDecParams->numGopReferenceSlots; resId++) {
             // slotLayer requires NVIDIA specific extension VK_KHR_video_layers, not enabled, just yet.
             // pGopReferenceSlots[resId].slotLayerIndex = 0;
             // pictureResourcesInfo[resId].image can be a nullptr handle if the picture is not-existent.

--- a/vk_video_decoder/libs/VkVideoParser/VulkanVideoParser.cpp
+++ b/vk_video_decoder/libs/VkVideoParser/VulkanVideoParser.cpp
@@ -1766,11 +1766,11 @@ uint32_t VulkanVideoParser::FillDpbAV1State(
         printf("\n");
 
         printf("ref_frame_picture: ");
-        for (int32_t inIdx = 0; inIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; inIdx++) {
+        for (uint32_t inIdx = 0; inIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; inIdx++) {
             printf("%02d ", inIdx);
         }
         printf("\nref_frame_picture: ");
-        for (int32_t inIdx = 0; inIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; inIdx++) {
+        for (uint32_t inIdx = 0; inIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; inIdx++) {
             int8_t picIdx = pin->pic_idx[inIdx];
             printf("%02d ", picIdx);
         }
@@ -1795,7 +1795,7 @@ uint32_t VulkanVideoParser::FillDpbAV1State(
         //hdr.delta_frame_id_minus_1[dpbSlot] = pin->delta_frame_id_minus_1[pin->ref_frame_idx[i]];
     }
 
-    for (int32_t inIdx = 0; inIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; inIdx++) {
+    for (uint32_t inIdx = 0; inIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; inIdx++) {
         int8_t picIdx = isKeyFrame ? -1 : pin->pic_idx[inIdx];
         int8_t dpbSlot = -1;
         if ((picIdx >= 0) && !(refDpbUsedAndValidMask & (1 << picIdx))) {
@@ -1896,11 +1896,11 @@ uint32_t VulkanVideoParser::FillDpbVP9State(
     if (m_dumpDpbData) {
         printf(";;;; ======= VP9 DPB fill begin %d =======\n", m_nCurrentPictureID);
         printf("ref_frame_idx: "); {
-        for (int i = 0 ; i < STD_VIDEO_VP9_REFS_PER_FRAME; i++)
+        for (uint32_t i = 0 ; i < STD_VIDEO_VP9_REFS_PER_FRAME; i++)
             printf("%02d ", i);
         }
         printf("\nref_frame_idx: ");
-        for (int i = 0 ; i < STD_VIDEO_VP9_REFS_PER_FRAME; i++) {
+        for (uint32_t i = 0 ; i < STD_VIDEO_VP9_REFS_PER_FRAME; i++) {
             printf("%02d ", pin->ref_frame_idx[i]);
         }
         printf("\n");
@@ -1916,11 +1916,11 @@ uint32_t VulkanVideoParser::FillDpbVP9State(
         printf("\n");
 
         printf("ref_frame_picture: ");
-        for (int32_t inIdx = 0; inIdx < STD_VIDEO_VP9_NUM_REF_FRAMES; inIdx++) {
+        for (uint32_t inIdx = 0; inIdx < STD_VIDEO_VP9_NUM_REF_FRAMES; inIdx++) {
             printf("%02d ", inIdx);
         }
         printf("\nref_frame_picture: ");
-        for (int32_t inIdx = 0; inIdx < STD_VIDEO_VP9_NUM_REF_FRAMES; inIdx++) {
+        for (uint32_t inIdx = 0; inIdx < STD_VIDEO_VP9_NUM_REF_FRAMES; inIdx++) {
             int8_t picIdx = pin->pic_idx[inIdx];
             printf("%02d ", picIdx);
         }
@@ -1945,7 +1945,7 @@ uint32_t VulkanVideoParser::FillDpbVP9State(
         //hdr.delta_frame_id_minus_1[dpbSlot] = pin->delta_frame_id_minus_1[pin->ref_frame_idx[i]];
     }
 
-    for (int32_t inIdx = 0; inIdx < STD_VIDEO_VP9_NUM_REF_FRAMES; inIdx++) {
+    for (uint32_t inIdx = 0; inIdx < STD_VIDEO_VP9_NUM_REF_FRAMES; inIdx++) {
         int8_t picIdx = isKeyFrame ? -1 : pin->pic_idx[inIdx];
         int8_t dpbSlot = -1;
         if ((picIdx >= 0) && !(refDpbUsedAndValidMask & (1 << picIdx))) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -96,11 +96,11 @@ int EncoderConfigAV1::DoParseArguments(int argc, char* argv[])
                     READ_PARAM(i, lfConfig.flags.loop_filter_delta_update, bool);
                     if (lfConfig.flags.loop_filter_delta_update) {
                         READ_PARAM(i, lfConfig.update_ref_delta, uint8_t);
-                        for (int32_t j = 0; j < STD_VIDEO_AV1_TOTAL_REFS_PER_FRAME; j++) {
+                        for (uint32_t j = 0; j < STD_VIDEO_AV1_TOTAL_REFS_PER_FRAME; j++) {
                             READ_PARAM(i, lfConfig.loop_filter_ref_deltas[j], int8_t);
                         }
                         READ_PARAM(i, lfConfig.update_mode_delta, uint8_t);
-                        for (int32_t j = 0; j < STD_VIDEO_AV1_LOOP_FILTER_ADJUSTMENTS; j++) {
+                        for (uint32_t j = 0; j < STD_VIDEO_AV1_LOOP_FILTER_ADJUSTMENTS; j++) {
                             READ_PARAM(i, lfConfig.loop_filter_mode_deltas[j], int8_t);
                         }
                     }
@@ -115,7 +115,7 @@ int EncoderConfigAV1::DoParseArguments(int argc, char* argv[])
                 // parse CDEF params
                 READ_PARAM(i, cdefConfig.cdef_damping_minus_3, uint8_t);
                 READ_PARAM(i, cdefConfig.cdef_bits, uint8_t);
-                for (int32_t j = 0; j < (1 << cdefConfig.cdef_bits); j++) {
+                for (int8_t j = 0; j < (1 << cdefConfig.cdef_bits); j++) {
                     READ_PARAM(i, cdefConfig.cdef_y_pri_strength[j], uint8_t);
                     READ_PARAM(i, cdefConfig.cdef_y_sec_strength[j], uint8_t);
                     READ_PARAM(i, cdefConfig.cdef_uv_pri_strength[j], uint8_t);
@@ -131,10 +131,10 @@ int EncoderConfigAV1::DoParseArguments(int argc, char* argv[])
                 ++i;
                 customLrConfig = true;
                 // parse LR params
-                for (int32_t j = 0; j < STD_VIDEO_AV1_MAX_NUM_PLANES; j++) {
+                for (uint32_t j = 0; j < STD_VIDEO_AV1_MAX_NUM_PLANES; j++) {
                     READ_PARAM(i, lrConfig.FrameRestorationType[j], StdVideoAV1FrameRestorationType);
                 }
-                for (int32_t j = 0; j < STD_VIDEO_AV1_MAX_NUM_PLANES; j++) {
+                for (uint32_t j = 0; j < STD_VIDEO_AV1_MAX_NUM_PLANES; j++) {
                     READ_PARAM(i, lrConfig.LoopRestorationSize[j], uint16_t);
                 }
             }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.cpp
@@ -170,7 +170,7 @@ int32_t VkEncDpbAV1::DpbSequenceStart(const VkSharedBaseObj<EncoderConfigAV1>& e
         m_maxRefFramesGroup2 = 3;
     }
 
-    for (int32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
         m_refBufIdMap[i] = i;
     }
 
@@ -255,7 +255,7 @@ int32_t VkEncDpbAV1::GetRefFrameDpbId(StdVideoAV1ReferenceName refName)
 
             int32_t refBufId = m_refBufIdMap[refName];
 
-            if ((refBufId >= 0) && (refBufId < STD_VIDEO_AV1_NUM_REF_FRAMES)) {
+            if ((refBufId >= 0) && (refBufId < static_cast<int32_t>(STD_VIDEO_AV1_NUM_REF_FRAMES))) {
                 refFrameDpbId = m_refFrameDpbIdMap[refBufId];
             }
     }
@@ -279,7 +279,7 @@ int8_t VkEncDpbAV1::GetRefBufDpbId(int32_t refBufId)
 {
     int8_t refBufDpbId = INVALID_IDX;
 
-    if ((refBufId >= 0) && (refBufId < STD_VIDEO_AV1_NUM_REF_FRAMES)) {
+    if ((refBufId >= 0) && (refBufId < static_cast<int32_t>(STD_VIDEO_AV1_NUM_REF_FRAMES))) {
             refBufDpbId = m_refFrameDpbIdMap[refBufId];
     }
 
@@ -293,14 +293,14 @@ int32_t VkEncDpbAV1::GetOverlayRefBufId(int32_t picOrderCntVal)
     for (auto ref : refNameFullList) {
 
         int32_t refBufId = m_refBufIdMap[ref];
-        if (refBufId >= STD_VIDEO_AV1_NUM_REF_FRAMES) continue;
+        if (refBufId >= static_cast<int32_t>(STD_VIDEO_AV1_NUM_REF_FRAMES)) continue;
 
         int32_t refBufDpbId = m_refFrameDpbIdMap[refBufId];
         if (refBufDpbId >= m_maxDpbSize) {
             continue;
         }
 
-        if ((GetRefCount(refBufDpbId) > 0) && (m_DPB[refBufDpbId].picOrderCntVal == (uint32_t)picOrderCntVal)) {
+        if ((GetRefCount(refBufDpbId) > 0) && (m_DPB[refBufDpbId].picOrderCntVal == static_cast<int32_t>(picOrderCntVal))) {
             // found valid match
             overlayRefBufId = refBufId;
             break;
@@ -498,7 +498,7 @@ int32_t VkEncDpbAV1::GetRefreshFrameFlags(bool bShownKeyFrameOrSwitch, bool bSho
     } else if (bShowExistingFrame) {
         refreshFrameFlags = 0;
     } else {
-        for (int32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+        for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
             if (m_refBufUpdateFlag & (1 << i)) {
                 int32_t refBufId = GetRefBufId((StdVideoAV1ReferenceName)i);
                 if (refBufId == VkEncDpbAV1::INVALID_IDX) continue;
@@ -512,7 +512,7 @@ int32_t VkEncDpbAV1::GetRefreshFrameFlags(bool bShownKeyFrameOrSwitch, bool bSho
 
 void VkEncDpbAV1::UpdateRefFrameDpbIdMap(int8_t dpbIndx)
 {
-    for (int i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
+    for (uint32_t i = 0; i < STD_VIDEO_AV1_NUM_REF_FRAMES; i++) {
 
         if (((m_refBufUpdateFlag >> i) & 1) == 1) {
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.cpp
@@ -230,9 +230,9 @@ void VkEncDpbH265::DpbBumping() {
 
 bool VkEncDpbH265::GetRefPicture(int8_t dpbIndex, VkSharedBaseObj<VulkanVideoImagePoolNode>& dpbImageView)
 {
-    assert(dpbIndex < STD_VIDEO_H265_MAX_DPB_SIZE);
+    assert((uint32_t)dpbIndex < STD_VIDEO_H265_MAX_DPB_SIZE);
 
-    if (!(dpbIndex < STD_VIDEO_H265_MAX_DPB_SIZE)) {
+    if (!((uint32_t)dpbIndex < STD_VIDEO_H265_MAX_DPB_SIZE)) {
         return false;
     }
 
@@ -298,20 +298,20 @@ void VkEncDpbH265::ApplyReferencePictureSet(const StdVideoEncodeH265PictureInfo 
         int32_t DeltaPocS0[STD_VIDEO_H265_MAX_DPB_SIZE], DeltaPocS1[STD_VIDEO_H265_MAX_DPB_SIZE];
 
         uint32_t numLongTermRefPics = 0;
-        int32_t numRefPics = pShortTermRefPicSet->num_negative_pics + pShortTermRefPicSet->num_positive_pics;
+        uint32_t numRefPics = pShortTermRefPicSet->num_negative_pics + pShortTermRefPicSet->num_positive_pics;
         if ((pLongTermRefPicsSps != nullptr) && (pLongTermRefPics != nullptr)) {
             numLongTermRefPics = pLongTermRefPics->num_long_term_sps + pLongTermRefPics->num_long_term_pics;
 
             numRefPics += numLongTermRefPics;
         }
 
-        if (numRefPics > (m_dpbSize - 1)) {
+        if (numRefPics > (uint32_t)(m_dpbSize - 1)) {
             printf("too many reference frames (%d, max is %d)\n", numRefPics, (m_dpbSize - 1));
         }
 
         assert(numRefPics <= STD_VIDEO_H265_MAX_NUM_LIST_REF);
 
-        int8_t i = 0, j = 0, k = 0;
+        uint8_t i = 0, j = 0, k = 0;
 
         for (i = 0; i < pShortTermRefPicSet->num_negative_pics; i++) {
             DeltaPocS0[i] = (i == 0) ? -(pShortTermRefPicSet->delta_poc_s0_minus1[i] + 1) :
@@ -544,7 +544,7 @@ void VkEncDpbH265::SetupReferencePictureListLx(StdVideoH265PictureType picType,
         }
     }
 
-    for (int32_t refidx = 0; refidx < STD_VIDEO_H265_MAX_NUM_LIST_REF; refidx++) {
+    for (uint32_t refidx = 0; refidx < STD_VIDEO_H265_MAX_NUM_LIST_REF; refidx++) {
         pRefLists->RefPicList0[refidx] = STD_VIDEO_H265_NO_REFERENCE_PICTURE;
         pRefLists->RefPicList1[refidx] = STD_VIDEO_H265_NO_REFERENCE_PICTURE;
     }
@@ -927,9 +927,9 @@ void VkEncDpbH265::InitializeRPS(const StdVideoH265ShortTermRefPicSet *pSpsShort
                                  pPicInfo, pShortTermRefPicSet, numRefL0, numRefL1);
 }
 
-uint32_t VkEncDpbH265::GetDirtyIntraRefreshRegions(int32_t dpb_idx)
+uint32_t VkEncDpbH265::GetDirtyIntraRefreshRegions(uint32_t dpb_idx)
 {
-    if ((dpb_idx >= 0) && (dpb_idx < STD_VIDEO_H265_MAX_DPB_SIZE) && (m_stDpb[dpb_idx].state != 0)) {
+    if ((dpb_idx < STD_VIDEO_H265_MAX_DPB_SIZE) && (m_stDpb[dpb_idx].state != 0)) {
         return (m_stDpb[dpb_idx].dirtyIntraRefreshRegions);
     }
     return 0;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.h
@@ -88,7 +88,7 @@ public:
 
     void ReferencePictureListIntializationLx(int32_t refPicListLx[2][STD_VIDEO_H265_MAX_NUM_LIST_REF], int32_t refPicListSize[2], const StdVideoEncodeH265SliceSegmentHeader *slh);
 
-    uint32_t GetDirtyIntraRefreshRegions(int32_t dpbIdx);
+    uint32_t GetDirtyIntraRefreshRegions(uint32_t dpbIdx);
     void SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions);
 
 private:
@@ -113,13 +113,13 @@ private:
 private:
     DpbEntryH265                   m_stDpb[STD_VIDEO_H265_MAX_DPB_SIZE];
     int8_t                         m_curDpbIndex;
-    int8_t                         m_dpbSize;
+    uint8_t                        m_dpbSize;
 
-    int8_t                         m_numPocStCurrBefore;
-    int8_t                         m_numPocStCurrAfter;
-    int8_t                         m_numPocStFoll;
-    int8_t                         m_numPocLtCurr;
-    int8_t                         m_numPocLtFoll;
+    uint8_t                        m_numPocStCurrBefore;
+    uint8_t                        m_numPocStCurrAfter;
+    uint8_t                        m_numPocStFoll;
+    uint8_t                        m_numPocLtCurr;
+    uint8_t                        m_numPocLtFoll;
 
     uint64_t                       m_lastIDRTimeStamp;
     int32_t                        m_picOrderCntCRA;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -678,7 +678,7 @@ void VkVideoEncoderAV1::InitializeFrameHeader(StdVideoAV1SequenceHeader* pSequen
                 pStdPictureInfo->ref_frame_idx[ref - STD_VIDEO_AV1_REFERENCE_NAME_LAST_FRAME] = (int8_t)m_dpbAV1->GetRefBufId(ref);
             }
 
-            for (int32_t bufIdx = 0; bufIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; bufIdx++) {
+            for (uint32_t bufIdx = 0; bufIdx < STD_VIDEO_AV1_NUM_REF_FRAMES; bufIdx++) {
                 int32_t dpbIdx = m_dpbAV1->GetRefBufDpbId(bufIdx);
                 assert(dpbIdx != VkEncDpbAV1::INVALID_IDX);
                 pStdPictureInfo->ref_order_hint[bufIdx] = (uint8_t)m_dpbAV1->GetPicOrderCntVal(dpbIdx);


### PR DESCRIPTION
Since the update of the vulkan-headers to v1.4.323, the build warns out a lot of signed/unsigned issues.

See https://github.com/KhronosGroup/Vulkan-Headers/commit/088a00d81d1fc30ff77aacf31485871aebec7cb2#diff-63533ad576f78ac25c721fd6dd83c6e4ff313f38e12b41c7263bda8de3b672d6R25