### PR TITLE
VkEncoderConfig: add profile argument for h26x

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -93,12 +93,16 @@ void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR)) {
         fprintf(stderr, "\nH264 specific arguments:\n\
-        --slices                        <integer> : Number of slices to divide the picture into\n");
+        --slices                        <integer> : Number of slices to divide the picture into\n\
+        --profile                       <integer> or <string>: select different encoding profile: \n\
+                                        baseline(0), main(1), high(2), high444(3)\n");
     }
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR)) {
         fprintf(stderr, "\nH265 specific arguments:\n\
-        --slices                        <integer> : Number of slices to divide the picture into\n");
+        --slices                        <integer> : Number of slices to divide the picture into\n\
+        --profile                       <integer> or <string>: select different encoding profile: \n\
+                                        main(0), main10(1), mainstill(2), range(3), scc(4)\n");
     }
 
     if ((codec == VK_VIDEO_CODEC_OPERATION_NONE_KHR) || (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR)) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -26,6 +26,24 @@ int EncoderConfigH264::DoParseArguments(int argc, char* argv[])
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;
             }
+        } else if (args[i] == "--profile") {
+            if (++i >= argc) {
+                fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+            std::string profileStr = args[i];
+            if (profileStr == "baseline" || profileStr == "0") {
+                profileIdc = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
+            } else if (profileStr == "main" || profileStr == "1") {
+                profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
+            } else if (profileStr == "high" || profileStr == "2") {
+                profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH;
+            } else if (profileStr == "high444" || profileStr == "3") {
+                profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
+            } else {
+                fprintf(stderr, "Invalid H.264 profile: %s\n", profileStr.c_str());
+                return -1;
+            }
         } else {
             fprintf(stderr, "Unrecognized option: %s\n", argv[i]);
             return -1;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -77,6 +77,26 @@ int EncoderConfigH265::DoParseArguments(int argc, char* argv[])
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;
             }
+        } else if (args[i] == "--profile") {
+            if (++i >= argc) {
+                fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+            std::string profileStr = args[i];
+            if (profileStr == "main" || profileStr == "0") {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN;
+            } else if (profileStr == "main10" || profileStr == "1") {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN_10;
+            } else if (profileStr == "mainstill" || profileStr == "2") {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN_STILL_PICTURE;
+            } else if (profileStr == "range" || profileStr == "3") {
+                profile = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
+            } else if (profileStr == "scc" || profileStr == "4") {
+                profile = STD_VIDEO_H265_PROFILE_IDC_SCC_EXTENSIONS;
+            } else {
+                fprintf(stderr, "Invalid H.265 profile: %s\n", profileStr.c_str());
+                return -1;
+            }
         } else {
             fprintf(stderr, "Unrecognized option: %s\n", argv[i]);
             return -1;


### PR DESCRIPTION
Add an argument --profile for h264 and h265 to
set the profile used by the encoder.