### PR TITLE
EncoderConfigH264: use ADAPTIVE_TRANSFORM_AUTOSELECT

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -312,6 +312,11 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
 
     if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_ENABLE) {
         pps->flags.transform_8x8_mode_flag = true;
+        if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_BASELINE) ||
+            (profileIdc == STD_VIDEO_H264_PROFILE_IDC_MAIN)) {
+            fprintf(stderr, "The profile selected does not support transform_8x8_mode_flag, disabling it.\n");
+            pps->flags.transform_8x8_mode_flag = false;
+        }
     } else if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_DISABLE) {
         pps->flags.transform_8x8_mode_flag = false;
     } else {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -69,7 +69,7 @@ struct EncoderConfigH264 : public EncoderConfig {
         , numRefL1(0)
         , numRefFrames(0)
         , entropyCodingMode(ENTROPY_CODING_MODE_CABAC)
-        , adaptiveTransformMode(ADAPTIVE_TRANSFORM_ENABLE)
+        , adaptiveTransformMode(ADAPTIVE_TRANSFORM_AUTOSELECT)
         , spsId(0)
         , ppsId()
         , numSlicesPerPicture(DEFAULT_NUM_SLICES_PER_PICTURE)


### PR DESCRIPTION
In order to use the baseline or main profile,
transform_8x8_mode_flag should not be set to true. Use the auto select which is more appropriate here.

In case ADAPTIVE_TRANSFORM_ENABLE is used, disable it and warn user that this option can not be used with baseline and main profile.