### PR TITLE
common: remove unused variable

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.cpp
@@ -27,7 +27,6 @@ VkResult VulkanFilterYuvCompute::Create(const VulkanDeviceContext* vkDevCtx,
                                         VkFormat inputFormat,
                                         VkFormat outputFormat,
                                         const VkSamplerYcbcrConversionCreateInfo* pYcbcrConversionCreateInfo,
-                                        const YcbcrPrimariesConstants* pYcbcrPrimariesConstants,
                                         const VkSamplerCreateInfo* pSamplerCreateInfo,
                                         VkSharedBaseObj<VulkanFilter>& vulkanFilter)
 {
@@ -38,8 +37,7 @@ VkResult VulkanFilterYuvCompute::Create(const VulkanDeviceContext* vkDevCtx,
                                                                                          flterType,
                                                                                          maxNumFrames,
                                                                                          inputFormat,
-                                                                                         outputFormat,
-                                                                                         pYcbcrPrimariesConstants));
+                                                                                         outputFormat));
 
     if (!yCbCrVulkanFilter) {
        return VK_ERROR_OUT_OF_HOST_MEMORY;

--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.h
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.h
@@ -41,7 +41,6 @@ public:
                            VkFormat inputFormat,
                            VkFormat outputFormat,
                            const VkSamplerYcbcrConversionCreateInfo* pYcbcrConversionCreateInfo,
-                           const YcbcrPrimariesConstants* pYcbcrPrimariesConstants,
                            const VkSamplerCreateInfo* pSamplerCreateInfo,
                            VkSharedBaseObj<VulkanFilter>& vulkanFilter);
 
@@ -51,8 +50,7 @@ public:
                            FilterType filterType,
                            uint32_t maxNumFrames,
                            VkFormat inputFormat,
-                           VkFormat outputFormat,
-                           const YcbcrPrimariesConstants* pYcbcrPrimariesConstants)
+                           VkFormat outputFormat)
         : VulkanFilter(vkDevCtx, queueFamilyIndex, queueIndex)
         , m_filterType(filterType)
         , m_inputFormat(inputFormat)
@@ -60,9 +58,6 @@ public:
         , m_workgroupSizeX(16)
         , m_workgroupSizeY(16)
         , m_maxNumFrames(maxNumFrames)
-        , m_ycbcrPrimariesConstants (pYcbcrPrimariesConstants ?
-                                        *pYcbcrPrimariesConstants :
-                                        YcbcrPrimariesConstants{0.0, 0.0})
         , m_inputImageAspects(  VK_IMAGE_ASPECT_COLOR_BIT |
                                 VK_IMAGE_ASPECT_PLANE_0_BIT |
                                 VK_IMAGE_ASPECT_PLANE_1_BIT |
@@ -346,7 +341,6 @@ private:
     uint32_t                                 m_workgroupSizeX; // usually 16
     uint32_t                                 m_workgroupSizeY; // usually 16
     uint32_t                                 m_maxNumFrames;
-    const YcbcrPrimariesConstants            m_ycbcrPrimariesConstants;
     VulkanSamplerYcbcrConversion             m_samplerYcbcrConversion;
     VulkanDescriptorSetLayout                m_descriptorSetLayout;
     VulkanComputePipeline                    m_computePipeline;

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -280,8 +280,6 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
                 pVideoFormat->video_signal_description.video_full_range_flag);
         const VkSamplerYcbcrModelConversion ycbcrModelConversion = VkVideoCoreProfile::CodecColorPrimariesToYCbCrModel(
                 pVideoFormat->video_signal_description.color_primaries);
-        const YcbcrPrimariesConstants ycbcrPrimariesConstants = VkVideoCoreProfile::CodecGetMatrixCoefficients(
-                pVideoFormat->video_signal_description.matrix_coefficients);
 
         const VkFormat inputFormat = dpbImageFormat;
         const VkFormat outputFormat = outImageFormat;
@@ -322,7 +320,6 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
                                                 inputFormat,
                                                 outputFormat,
                                                 &ycbcrConversionCreateInfo,
-                                                &ycbcrPrimariesConstants,
                                                 &samplerInfo,
                                                 m_yuvFilter);
         if (result == VK_SUCCESS) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1178,7 +1178,6 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
 
         const VkSamplerYcbcrRange ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL; // FIXME
         const VkSamplerYcbcrModelConversion ycbcrModelConversion = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;   // FIXME
-        const YcbcrPrimariesConstants ycbcrPrimariesConstants = GetYcbcrPrimariesConstants(YcbcrBtStandardBt2020); // FIXME
 
         const VkSamplerYcbcrConversionCreateInfo ycbcrConversionCreateInfo {
                    VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
@@ -1216,7 +1215,6 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
                                                 m_imageInFormat,  // in filter format (can be RGB)
                                                 m_imageInFormat,  // out filter - same as input for now.
                                                 &ycbcrConversionCreateInfo,
-                                                &ycbcrPrimariesConstants,
                                                 &samplerInfo,
                                                 m_inputComputeFilter);
     }


### PR DESCRIPTION
Remove m_ycbcrPrimariesConstants which is
unused in the codebase.