### PR TITLE
EncoderConfig: warn about production feature only in verbose

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -74,7 +74,7 @@ void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     --intraRefreshCycleDuration     <integer> : Duration of (number of frames in) an intra-refresh cycle\n\
     --intraRefreshMode              <string>  : Intra-refresh mode to be used\n\
                                         picpartition, blockrows, blockcolumns, blocks\n\
-    --testIntraRefreshMidway        <integer> : Index at which an intra-refresh cycle is to be interrupted.\n\
+    --testIntraRefreshMidway        <integer> : Testing only - Index at which an intra-refresh cycle is to be interrupted.\n\
                                         This is for testing purposes only. Allowed values for this option\n\
                                         are such that 0 <= index < intraRefreshCycleDuration .\n\
                                         A value of 0 is a no-op; for other values, a new intra-refresh\n\
@@ -82,7 +82,7 @@ void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
                                         cycle and a complete cycle will be finished. This results in\n\
                                         a fully intra-refreshed frame being available after every\n\
                                         `intraRefreshCycleDuration + index` frames.\n\
-    --testSkipIntraRefreshStart     <integer> : Index at which an intra-refresh cycle should start.\n\
+    --testSkipIntraRefreshStart     <integer> : Testing only - Index at which an intra-refresh cycle should start.\n\
                                         This is for testing purposes only. Allowed values for this option\n\
                                         are such that 0 <= index < intraRefreshCycleDuration .\n\
                                         A value of 0 is a no-op; for other values, a new intra-refresh\n\
@@ -543,7 +543,9 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
             }
         } else if (args[i] == "--testIntraRefreshMidway") {
             // Testing only - don't use this feature for production!
-            fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
+            if (verbose) {
+                fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
+            }
             if (++i >= argc || sscanf(args[i].c_str(), "%u", &intraRefreshCycleRestartIndex) != 1) {
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;
@@ -551,7 +553,9 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
             gopStructure.SetIntraRefreshCycleRestartIndex(intraRefreshCycleRestartIndex);
         } else if (args[i] == "--testSkipIntraRefreshStart") {
             // Testing only - don't use this feature for production!
-            fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
+            if (verbose) {
+                fprintf(stdout, "Warning: %s should only be used for testing!\n", args[i].c_str());
+            }
             if (++i >= argc || sscanf(args[i].c_str(), "%u", &intraRefreshSkippedStartIndex) != 1) {
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;


### PR DESCRIPTION
--testIntraRefreshMidway and --testSkipIntraRefreshStart should be reported as "used for testing only" in verbose mode.

The warning was printed many times while testing with the Vulkan CTS. Since arguments are being passed, it's obvious that the intention is to use it "for testing", therefore the warning is fairly intrusive.