### PR TITLE
WAR for frames that are displayed more than once

### DIFF
--- a/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
+++ b/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
@@ -206,13 +206,14 @@ public:
         assert(pOutputBuffer != nullptr);
 
         assert((pFrame->displayWidth >= 0) && (pFrame->displayHeight >= 0));
-
-        WaitAndGetStatus(vkDevCtx,
+        if (pFrame->frameCompleteFence) {
+            WaitAndGetStatus(vkDevCtx,
                         *vkDevCtx,
                         pFrame->frameCompleteFence,
                         pFrame->queryPool,
                         pFrame->startQueryId,
                         pFrame->pictureIndex, false, "frameCompleteFence");
+        }
 
         VkFormat format = imageResource->GetImageCreateInfo().format;
         const VkMpFormatInfo* mpInfo = YcbcrVkFormatInfo(format);


### PR DESCRIPTION
Fixing the playback of `vp90-2-10-show-existing-frame.webm/vp90-2-10-show-existing-frame.webm` in VP9-Test-Vectors