### PR TITLE
Helpers: Add file path validation

### DIFF
--- a/common/libs/VkCodecUtils/DecoderConfig.h
+++ b/common/libs/VkCodecUtils/DecoderConfig.h
@@ -200,16 +200,17 @@ struct DecoderConfig {
                 }},
             {"--input", "-i", 1, "Input filename to decode",
                 [this](const char **args, const ProgramArgs &a) {
-                    videoFileName = args[0];
-                    std::ifstream inputFile(videoFileName, std::ifstream::in);
-                    if(!inputFile.is_open()) {
-                        std::cerr << "Error: Cannot open input file \"" << videoFileName << "\"" << std::endl;
+                    if (!vk::IsValidFilePath(args[0], true)) {
                         return false;
                     }
+                    videoFileName = args[0];
                     return true;
                 }},
             {"--output", "-o", 1, "Output filename to dump raw video to",
                 [this](const char **args, const ProgramArgs &a) {
+                    if (!vk::IsValidFilePath(args[0], false)) {
+                        return false;
+                    }
                     outputFileName = args[0];
                     return true;
                 }},
@@ -310,6 +311,9 @@ struct DecoderConfig {
                 }},
             {"--crcoutfile", nullptr, 1, "Output file to store the CRC output into.",
                     [this](const char **args, const ProgramArgs &a) {
+                    if (!vk::IsValidFilePath(args[0], false)) {
+                        return false;
+                    }
                     crcOutputFileName = args[0];
                     return true;
                 }},

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -43,7 +43,8 @@ int main(int argc, const char **argv)
                                         decoderConfig.initialBitdepth,
                                         videoStreamDemuxer);
     if (result != VK_SUCCESS) {
-        assert(!"Can't initialize the VideoStreamDemuxer!");
+        fprintf(stderr, "Error: Failed to initialize VideoStreamDemuxer for file: %s\n",
+                decoderConfig.videoFileName.c_str());
         return -1;
     }
 

--- a/vk_video_decoder/libs/VkDecoderUtils/VideoStreamDemuxer.cpp
+++ b/vk_video_decoder/libs/VkDecoderUtils/VideoStreamDemuxer.cpp
@@ -18,16 +18,6 @@
 #include <fstream>
 #include "VkDecoderUtils/VideoStreamDemuxer.h"
 
-bool VideoStreamDemuxer::CheckFile(const char* szInFilePath)
-{
-    std::ifstream fpIn(szInFilePath, std::ios::in | std::ios::binary);
-    if (fpIn.fail()) {
-        std::ostringstream err;
-        err << "Unable to open input file: " << szInFilePath << std::endl;
-        throw std::invalid_argument(err.str());
-    }
-    return true;
-}
 
 VkResult VideoStreamDemuxer::Create(const char *pFilePath,
                                     VkVideoCodecOperationFlagBitsKHR codecType,
@@ -37,8 +27,6 @@ VkResult VideoStreamDemuxer::Create(const char *pFilePath,
                                     int32_t defaultBitDepth,
                                     VkSharedBaseObj<VideoStreamDemuxer>& videoStreamDemuxer)
 {
-    VideoStreamDemuxer::CheckFile(pFilePath);
-
 #ifdef FFMPEG_DEMUXER_SUPPORT
     if (requiresStreamDemuxing || (codecType == VK_VIDEO_CODEC_OPERATION_NONE_KHR)) {
         return FFmpegDemuxerCreate(pFilePath,

--- a/vk_video_decoder/libs/VkDecoderUtils/VideoStreamDemuxer.h
+++ b/vk_video_decoder/libs/VkDecoderUtils/VideoStreamDemuxer.h
@@ -34,8 +34,6 @@ public:
                            int32_t defaultBitDepth = 12,
                            VkSharedBaseObj<VideoStreamDemuxer>& videoStreamDemuxer = invalidDemuxer);
 
-    static bool CheckFile(const char* szInFilePath);
-
     virtual int32_t AddRef()
     {
         return ++m_refCount;

--- a/vk_video_decoder/test/vulkan-video-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-dec/Main.cpp
@@ -70,8 +70,9 @@ int main(int argc, const char** argv)
                                         decoderConfig.initialBitdepth,
                                         videoStreamDemuxer);
     if (result != VK_SUCCESS) {
-        assert(!"Can't initialize the VideoStreamDemuxer!");
-        return result;
+        fprintf(stderr, "Error: Failed to initialize VideoStreamDemuxer for file: %s\n",
+                decoderConfig.videoFileName.c_str());
+        return -1;
     }
 
     const int32_t numDecodeQueues = ((decoderConfig.queueId != 0) ||

--- a/vk_video_decoder/test/vulkan-video-simple-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-simple-dec/Main.cpp
@@ -133,8 +133,9 @@ int main(int argc, const char** argv)
                                                  videoStreamDemuxer);
 
     if (result != VK_SUCCESS) {
-        assert(!"Can't initialize the VideoStreamDemuxer!");
-        return result;
+        fprintf(stderr, "Error: Failed to initialize VideoStreamDemuxer for file: %s\n",
+                decoderConfig.videoFileName.c_str());
+        return -1;
     }
 
     VkSharedBaseObj<VkVideoFrameOutput> frameToFile;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -172,6 +172,9 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
                 return -1;
             }
+            if (!vk::IsValidFilePath(args[i].c_str(), true)) {
+                return -1;
+            }
             size_t fileSize = inputFileHandler.SetFileName(args[i].c_str());
             if (fileSize <= 0) {
                 return (int)fileSize;
@@ -184,6 +187,9 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
         } else if (args[i] == "-o" || args[i] == "--output") {
             if (++i >= argc) {
                 fprintf(stderr, "invalid parameter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+            if (!vk::IsValidFilePath(args[i].c_str(), false)) {
                 return -1;
             }
             size_t fileSize = outputFileHandler.SetFileName(args[i].c_str());
@@ -496,6 +502,9 @@ int EncoderConfig::ParseArguments(int argc, char *argv[])
         } else if (args[i] == "--qpMapFileName") {
             if (++i >= argc) {
                 fprintf(stderr, "Invaid paramter for %s\n", args[i - 1].c_str());
+                return -1;
+            }
+            if (!vk::IsValidFilePath(args[i].c_str(), true)) {
                 return -1;
             }
             size_t fileSize = qpMapFileHandler.SetFileName(args[i].c_str());

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include "mio/mio.hpp"
 #include "VkCodecUtils/VkVideoRefCountBase.h"
+#include "VkCodecUtils/Helpers.h"
 #include "VkVideoEncoder/VkVideoEncoderDef.h"
 #include "VkVideoEncoder/VkVideoGopStructure.h"
 #include "VkVideoCore/VkVideoCoreProfile.h"


### PR DESCRIPTION
Add vk::IsValidFilePath() helper to validate file paths before opening. Checks for null/empty paths, file existence, and regular file type.

In order to address an enigmatic message such as:

```
$ ./vk_video_decoder/demos/vk-video-dec-test -i /home
General error -21 at line 204 in file //DEV/Vulkan-Video-Samples/vk_video_decoder/libs/VkDecoderUtils/FFmpegDemuxer.cppNo AVFormatContext provided.vk-video-dec-test: /home/scerveau/DEV/PROJECTS/VALVE/DEV/Vulkan-Video-Samples/vk_video_decoder/demos/vk-video-dec/Main.cpp:46: int main(int, const char**): Assertion `!"Can't initialize the VideoStreamDemuxer!"' failed.
Aborted (core dumped)
```