### PR TITLE
Initialize filmGrainSupport when setting up AV1 profile.

### DIFF
--- a/common/include/VkVideoCore/VkVideoCoreProfile.h
+++ b/common/include/VkVideoCore/VkVideoCoreProfile.h
@@ -246,6 +246,7 @@ public:
                 assert(false && "Bad profile IDC");
             }
             decodeAV1ProfilesRequest.stdProfile = (StdVideoAV1Profile)videoH26xProfileIdc;
+            decodeAV1ProfilesRequest.filmGrainSupport = false;
             pVideoProfileExt = (VkBaseInStructure*)&decodeAV1ProfilesRequest;
         } else if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR) {
             decodeH265ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR;


### PR DESCRIPTION
Set 0 to filmGrainSupport by default, otherwise garbage is going to be set, which can lead to a failure on drivers that doesn't support filmGrain.

This also fixes av1 decoding on ANV drivers.