### PR TITLE
FFmpegDemuxer: Strip higher bits of profile

### DIFF
--- a/vk_video_decoder/libs/VkDecoderUtils/FFmpegDemuxer.cpp
+++ b/vk_video_decoder/libs/VkDecoderUtils/FFmpegDemuxer.cpp
@@ -88,7 +88,7 @@ private:
         /**
          * Codec-specific bitstream restrictions that the stream conforms to.
          */
-        profile = fmtc->streams[videoStream]->codecpar->profile;
+        profile = fmtc->streams[videoStream]->codecpar->profile & 0xFF; /* constraint_set_flags in higher bits */
         level = fmtc->streams[videoStream]->codecpar->level;
 
         /**


### PR DESCRIPTION
libavcodec outputs the H.264 `constraint_set_flags` in the higher bits of this. When these extended values get passed to Vulkan as stdProfileIdc, the driver may indicate they do not support such "bogus" values.

The only lavc codec that uses the higher bits is H.264, so it is safe to keep only the lower bits.