### PR TITLE
common: remove warning for unused variable

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFilterYuvCompute.h
+++ b/common/libs/VkCodecUtils/VulkanFilterYuvCompute.h
@@ -73,6 +73,8 @@ public:
                                 VK_IMAGE_ASPECT_PLANE_2_BIT)
         , m_enableRowAndColumnReplication(true)
     {
+        // FIXME: m_ycbcrPrimariesConstants is currently unused but is kept for future use.
+        (void)m_ycbcrPrimariesConstants;
     }
 
     VkResult Init(const VkSamplerYcbcrConversionCreateInfo* pYcbcrConversionCreateInfo,


### PR DESCRIPTION
Void m_ycbcrPrimariesConstants which
unused in the codebase.

Related to #102 

Able to reproduce the warnings/error in CTS:

```
python3 scripts/check_build_sanity.py --skip-prerequisites -r clang-64-debug -t ./tmp.PiN3LHSb8Z
```