### PR TITLE
Get count_trailing_zeros() to compile for MSVC 32-bit

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/include/cpudetect.h
+++ b/vk_video_decoder/libs/NvVideoParser/include/cpudetect.h
@@ -13,11 +13,19 @@ enum SIMD_ISA
 
 static int inline count_trailing_zeros(unsigned long long resmask)
 {
-#ifndef _WIN32
-    int offset = __builtin_ctzll(resmask);
-#else
+#ifdef _WIN64
     unsigned long offset = 0;
     const unsigned char dummyIsNonZero =_BitScanForward64(&offset, resmask); // resmask can't be 0 in this if
+#elif _WIN32
+    unsigned long offset = 0;
+    const unsigned char isNonZero = _BitScanForward(&offset, (unsigned long)(resmask >> 32U)); // resmask can't be 0 in this if
+    if (isNonZero) {
+        offset += 32U;
+    } else {
+        _BitScanForward(&offset, (unsigned long)resmask); // resmask can't be 0 in this if
+    }
+#else
+    int offset = __builtin_ctzll(resmask);
 #endif
     return offset;
 }


### PR DESCRIPTION
This was causing Vulkan CTS build to fail on MSVC Windows builds for 32-bit:
> P:\git\gerrit.khronos.org\vk-gl-cts\external\vulkan-video-samples\src\vk_video_decoder\libs\NvVideoParser\include\cpudetect.h(20,41): error C3861: '_     ': identifier not found
> (compiling source file '../../../external/vulkan-video-samples/src/vk_video_decoder/libs/NvVideoParser/src/NextStartCodeC.cpp')

This showed up with vulkan-cts-1.4.5.0, but probably has been around before that.
