### PR TITLE
ci: add commit message validation workflow

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,27 @@
+name: "Commit message validation"
+run-name: Commit lint by ${{ github.actor }}
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install commitlint
+        run: npm install --save-dev @commitlint/cli
+
+      - name: Validate commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,3 +1,44 @@
+# Contributing to Vulkan Video Samples
+
+## Commit Message Guidelines
+
+All commit messages must follow this format:
+
+```
+scope: description
+```
+
+### Scope
+
+The scope identifies the area of the codebase being changed:
+
+- **Lowercase** for general areas: `cmake`, `ci`, `docs`, `build`
+- **PascalCase** for components: `VkVideoDecoder`, `VkEncoderConfig`, `FindShaderc`
+- **Braces** for multiple components: `VkEncoderConfig{H264,H265}`
+
+### Rules
+
+- **Header length**: Maximum 100 characters
+- **Subject**: Must not be empty, must not end with a period
+- **No draft indicators**: Commits with WIP, fixup, squash, tmp, todo, hack, draft, or similar markers will be rejected
+
+### Examples
+
+```
+cmake: fix build issue with shaderc detection
+VkVideoDecoder: add support for AV1 profile
+docs: update build instructions for Fedora
+ci: add commit message validation workflow
+```
+
+### Validation
+
+Commit messages are automatically validated on pull requests via commitlint. See `commitlint.config.js` for the full ruleset.
+
+---
+
+## Developer Certificate of Origin
+
 https://developercertificate.org/
 
 Developer Certificate of Origin

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,46 @@
+module.exports = {
+  rules: {
+    // Enforce scope pattern: lowercase words OR PascalCase component names (with optional {})
+    'scope-pattern': [2, 'always'],
+    // Reject WIP and similar draft indicators
+    'no-wip': [2, 'always'],
+    // Header must not exceed 100 characters
+    'header-max-length': [2, 'always', 100],
+    // Subject must not be empty
+    'subject-empty': [2, 'never'],
+    // Subject must not end with period
+    'subject-full-stop': [2, 'never', '.'],
+  },
+  plugins: [
+    {
+      rules: {
+        'scope-pattern': ({ header }) => {
+          // Pattern: "scope: description" where scope is either:
+          // - lowercase word (cmake, ci, docs, etc.)
+          // - PascalCase component name (FindShaderc, VkEncoderConfig, etc.)
+          // - Component with braces (VkEncoderConfig{H264,H265})
+          const pattern = /^([a-z]+|[A-Z][a-zA-Z0-9]*(\{[^}]+\})?): .+/;
+          const valid = pattern.test(header);
+          return [
+            valid,
+            `Commit message must match pattern "scope: description"\n` +
+            `  - scope: lowercase (cmake, ci, docs) OR PascalCase (FindShaderc, VkEncoderConfig)\n` +
+            `  - Example: "cmake: fix build issue" or "VkEncoderConfig: add new option"\n` +
+            `  - Got: "${header}"`,
+          ];
+        },
+        'no-wip': ({ header }) => {
+          // Reject commits with draft indicators (case-insensitive)
+          const forbidden = /\b(wip|WIP|fixup|FIXUP|squash|SQUASH|tmp|TMP|todo|TODO|hack|HACK|xxx|XXX|do not merge|DO NOT MERGE|dnm|DNM|draft|DRAFT)\b/i;
+          const match = header.match(forbidden);
+          return [
+            !match,
+            `Commit message must not contain draft indicators like "${match ? match[0] : 'WIP'}"\n` +
+            `  - Forbidden (any case): WIP, fixup, squash, tmp, todo, hack, xxx, do not merge, dnm, draft\n` +
+            `  - Got: "${header}"`,
+          ];
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Add commitlint to validate PR commit messages with rules:
- Require "scope: description" format
- Reject draft indicators (WIP, fixup, squash, etc.)
- Enforce max 100 char header length