### PR TITLE
ci: add windows-x86 platform to build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,7 +183,7 @@ jobs:
   Vulkan-Video-Samples-win:
     strategy:
       matrix:
-        platform: [windows-x64, windows-x64-ffmpeg, win-arm64]
+        platform: [windows-x64, windows-x64-ffmpeg, windows-x86, win-arm64]
         include:
           - platform: windows-x64
             arch: x64
@@ -191,6 +191,9 @@ jobs:
           - platform: windows-x64-ffmpeg
             arch: x64
             cmake_arch: x64
+          - platform: windows-x86
+            arch: x86
+            cmake_arch: Win32
           - platform: win-arm64
             arch: arm64
             cmake_arch: ARM64


### PR DESCRIPTION
Add 32-bit Windows (x86) build configuration to the GitHub Actions workflow alongside the existing x64 and ARM64 builds. This enables CI testing for the Win32 architecture using cmake_arch Win32.

CTS also targets 32-bit Windows builds, so this ensures compatibility testing aligns with conformance requirements.