### PR TITLE
VulkanVideoProcessor: extend signal description tables and  fix bounds handling

### DIFF
--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
@@ -265,19 +265,21 @@ void VulkanVideoProcessor::DumpVideoFormat(const VkParserDetectedVideoFormat* vi
     /* These below token numbers are based on "chroma_format_idc" from the spec. */
     /* Also, mind the separate_colour_plane_flag, as well. */
     static const char* nvVideoChromaFormat[] = {
-        nullptr,
+        "Invalid",
         "Monochrome",
         "420",
-        nullptr,
+        "Invalid",
         "422",
-        nullptr,
-        nullptr,
-        nullptr,
+        "Invalid",
+        "Invalid",
+        "Invalid",
         "444",
     };
+    const char* pVideoChromaFormat = "Invalid";
     assert(videoFormat->chromaSubsampling < sizeof(nvVideoChromaFormat)/sizeof(nvVideoChromaFormat[0]));
-    assert(nvVideoChromaFormat[videoFormat->chromaSubsampling] != nullptr);
-    const char* pVideoChromaFormat = nvVideoChromaFormat[videoFormat->chromaSubsampling];
+    if (videoFormat->chromaSubsampling < sizeof(nvVideoChromaFormat)/sizeof(nvVideoChromaFormat[0])) {
+        pVideoChromaFormat = nvVideoChromaFormat[videoFormat->chromaSubsampling];
+    }
     if (dumpData) {
         std::cout << "VideoChromaFormat : " << pVideoChromaFormat << std::endl;
     }
@@ -294,8 +296,11 @@ void VulkanVideoProcessor::DumpVideoFormat(const VkParserDetectedVideoFormat* vi
         "Reserved6",
         "Reserved7",
     };
+    const char* pVideoFormat = "Invalid";
     assert(videoFormat->video_signal_description.video_format < sizeof(VideoFormat)/sizeof(VideoFormat[0]));
-    const char* pVideoFormat = VideoFormat[videoFormat->video_signal_description.video_format];
+    if (videoFormat->video_signal_description.video_format < sizeof(VideoFormat)/sizeof(VideoFormat[0])) {
+        pVideoFormat = VideoFormat[videoFormat->video_signal_description.video_format];
+    }
     if (dumpData) {
         std::cout << "VideoFormat : " << pVideoFormat << std::endl;
     }


### PR DESCRIPTION
This patch addresses a set of failed assertions when the values for color primaries, transfer characteristics and matrix coefficients are not specified in the corresponding tables.

This patch replaces assert-based bounds checks with a fallback to "Reserved" when values exceed the table size. As per the specification ITU-T H.273, the color primaries, transfer characteristics, and matrix coefficients are all unsigned integers with a range of 0 to 255, values not included directly in the table are reserved for future use and should therefore be allowed.

Additionally, add missing entries to video signal description lookup tables for color primaries, transfer characteristics, and matrix coefficients per ITU-T H.273.

Fixes Issue #123, where the test av1_argon_test1019 uses the following values:
- Color primaries: 234
- TransferCharacteristics: 229
- MatrixCoefficients : 255
