### PR TITLE
build: add macOS support for CPU detection and library linking

### DIFF
--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -307,7 +307,7 @@ bool VulkanDeviceContext::HasAllDeviceExtensions(VkPhysicalDevice physDevice, co
     return hasAllRequiredExtensions;
 }
 
-#ifndef _WIN32
+#if defined(__linux__)
 #include <link.h>
 static int DumpSoLibs()
 {
@@ -327,6 +327,19 @@ static int DumpSoLibs()
       map = map->l_next;
     }
 
+    return 0;
+}
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+static int DumpSoLibs()
+{
+    uint32_t count = _dyld_image_count();
+    for (uint32_t i = 0; i < count; i++) {
+        const char* name = _dyld_get_image_name(i);
+        if (name) {
+            std::cout << name << std::endl;
+        }
+    }
     return 0;
 }
 #endif

--- a/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
+++ b/vk_video_decoder/demos/vk-video-dec/CMakeLists.txt
@@ -104,7 +104,7 @@ if(FFMPEG_AVAILABLE)
     if(WIN32)
         list(APPEND libraries PUBLIC ${AVCODEC_LIB} ${AVFORMAT_LIB} ${AVUTIL_LIB})
     else()
-        list(APPEND libraries PRIVATE -lavcodec -lavutil -lavformat)
+        list(APPEND libraries PRIVATE ${FFMPEG_LIBAVCODEC_LIBRARIES} ${FFMPEG_LIBAVUTIL_LIBRARIES} ${FFMPEG_LIBAVFORMAT_LIBRARIES})
     endif()
 endif()
 

--- a/vk_video_decoder/libs/NvVideoParser/src/cpudetect.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/cpudetect.cpp
@@ -8,7 +8,7 @@
 
 #include <cpudetect.h>
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) && defined(__linux__)
 
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
@@ -100,10 +100,13 @@ SIMD_ISA check_simd_support()
     if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512bw")) { return SIMD_ISA::AVX512; }
     else if (__builtin_cpu_supports("avx2")) { return SIMD_ISA::AVX2; }
     else if (__builtin_cpu_supports("ssse3")) { return SIMD_ISA::SSSE3; };
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) && defined(__linux__)
     long hwcaps = getauxval(AT_HWCAP);
     if(hwcaps & HWCAP_SVE) { return SIMD_ISA::SVE; }
     else if(hwcaps & HWCAP_ASIMD) { return SIMD_ISA::NEON; }
+#elif defined(__aarch64__) && defined(__APPLE__)
+    // Apple Silicon always supports NEON (ASIMD)
+    return SIMD_ISA::NEON;
 #elif defined(__ARM_ARCH_7A__) || defined(_M_ARM64)
     return SIMD_ISA::NEON;
 #endif

--- a/vk_video_decoder/test/vulkan-video-dec/CMakeLists.txt
+++ b/vk_video_decoder/test/vulkan-video-dec/CMakeLists.txt
@@ -82,7 +82,7 @@ if(FFMPEG_AVAILABLE)
     if(WIN32)
         list(APPEND VULKAN_VIDEO_DEC_LIBRARIES PRIVATE ${AVCODEC_LIB} ${AVFORMAT_LIB} ${AVUTIL_LIB})
     else()
-        list(APPEND VULKAN_VIDEO_DEC_LIBRARIES PRIVATE -lavcodec -lavutil -lavformat)
+        list(APPEND VULKAN_VIDEO_DEC_LIBRARIES PRIVATE ${FFMPEG_LIBAVCODEC_LIBRARIES} ${FFMPEG_LIBAVUTIL_LIBRARIES} ${FFMPEG_LIBAVFORMAT_LIBRARIES})
     endif()
 endif()
 ######## END of TODO make FFMPEG linbraries and demuxer optional. ###################


### PR DESCRIPTION
Caution: This patch does not bring Vulkan Video support to MacOS but allow to build VVS on it.