### PR TITLE
build: add -Wundef warning flag and fix undefined macro usage

### DIFF
--- a/cmake/LinuxSettings.cmake
+++ b/cmake/LinuxSettings.cmake
@@ -84,7 +84,7 @@ endif()
 
 # Compiler flags for GCC/Clang
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wshadow")
+    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wundef -Wno-unused-parameter -Wno-missing-field-initializers -Wshadow")
     set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
 
     # Warning about implicit fallthrough in switch blocks

--- a/vk_video_decoder/libs/NvVideoParser/include/cpudetect.h
+++ b/vk_video_decoder/libs/NvVideoParser/include/cpudetect.h
@@ -20,7 +20,7 @@ static int inline count_trailing_zeros(unsigned long long resmask)
 #ifdef _WIN64
     unsigned long offset = 0;
     (void)_BitScanForward64(&offset, resmask);
-#elif _WIN32
+#elif defined(_WIN32)
     unsigned long offset = 0;
     unsigned long resmaskLsb = (unsigned long)(resmask & 0xFFFFFFFFULL);
     if (resmaskLsb != 0U) {


### PR DESCRIPTION
Enable -Wundef in COMMON_COMPILE_FLAGS to warn about undefined macros in preprocessor conditionals. Fix cpudetect.h to use defined(_WIN32) instead of bare _WIN32 check.