### PR TITLE
Testing framework hotfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,7 @@ python3 tests/video_test_framework_encode.py --test "encode_h264_*"
 ```
 
 For complete documentation, command-line options, and advanced usage examples, see **[tests/README.md](tests/README.md)**.
+
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING](CONTRIBUTING) for guidelines on commit messages, pull requests, and testing requirements.

--- a/common/include/VkVSCommon.h
+++ b/common/include/VkVSCommon.h
@@ -84,8 +84,11 @@ inline bool IsVideoUnsupportedResult(VkResult result) {
     return result == VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR ||
            result == VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR ||
            result == VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR ||
+           result == VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR ||
            result == VK_ERROR_FORMAT_NOT_SUPPORTED ||
-           result == VK_ERROR_FEATURE_NOT_PRESENT;
+           result == VK_ERROR_FEATURE_NOT_PRESENT ||
+           result == VK_ERROR_INCOMPATIBLE_DRIVER ||
+           result == VK_ERROR_EXTENSION_NOT_PRESENT;
 }
 
 #endif // __cplusplus

--- a/common/include/VkVSCommon.h
+++ b/common/include/VkVSCommon.h
@@ -78,9 +78,9 @@ inline const char* string_VkResult_Extended(VkResult result) {
 }
 
 // Helper function to check if a VkResult indicates video profile/feature not supported
-// Returns true if the error indicates the hardware/driver doesn't support the requested
-// video codec profile or feature (as opposed to an actual runtime error)
-inline bool IsVideoProfileNotSupportedError(VkResult result) {
+// Returns true for video-specific KHR errors (profile, format, codec, std version)
+// and general Vulkan capability errors (format, feature, driver, extension)
+inline bool IsVideoUnsupportedResult(VkResult result) {
     return result == VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR ||
            result == VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR ||
            result == VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR ||

--- a/common/libs/VkCodecUtils/VkVideoFrameOutput.h
+++ b/common/libs/VkCodecUtils/VkVideoFrameOutput.h
@@ -62,9 +62,10 @@ public:
      *
      * @param pFrame Pointer to the decoded frame
      * @param vkDevCtx Vulkan device context
-     * @return size_t Number of bytes written, (size_t)-1 on error
+     * @param bytesWritten Optional pointer to receive number of bytes written
+     * @return bool true on success, false on error
      */
-    virtual size_t OutputFrame(VulkanDecodedFrame* pFrame, const VulkanDeviceContext* vkDevCtx) = 0;
+    virtual bool OutputFrame(VulkanDecodedFrame* pFrame, const VulkanDeviceContext* vkDevCtx, size_t* bytesWritten = nullptr) = 0;
 
 protected:
     VkVideoFrameOutput() = default;

--- a/common/libs/VkCodecUtils/VkVideoQueue.h
+++ b/common/libs/VkCodecUtils/VkVideoQueue.h
@@ -21,6 +21,17 @@
 #include "VkCodecUtils/VkVideoRefCountBase.h"
 
 /**
+ * @enum VkVideoQueueResult
+ * @brief Result codes for VkVideoQueue::GetNextFrame operations.
+ */
+enum class VkVideoQueueResult {
+    NewFrame,
+    NoFrame,
+    EndOfStream,
+    Error
+};
+
+/**
  * @class VkVideoQueue
  * @brief Interface for retrieving frames from a Vulkan-based video queue.
  *
@@ -137,17 +148,15 @@ public:
      *                         information about the newly decoded frame, if available.
      *                         If no frame is currently available or it was the end of the stream,
      *                         there will be no data filled in pNewFrame.
-     * @param[out] endOfStream Set to `true` if the end of the stream has been reached (i.e., no more
-     *                         frames will ever be available), or `false` otherwise.
      *
      * @return
-     * - `1` if a decoded frame is successfully retrieved.
-     * - `0` if no frame is currently available (but not an error, you may need to parse more data or
-     *        wait for pending frames to be reordered because of the B-frames are present).
-     * - `-1` if an error occurs or if the end of the stream is reached. In either case, decoding should
-     *         be terminated or reset accordingly.
+     * - `VkVideoQueueResult::NewFrame` if a decoded frame is successfully retrieved.
+     * - `VkVideoQueueResult::NoFrame` if no frame is currently available (need more parsing
+     *    or B-frame reordering).
+     * - `VkVideoQueueResult::EndOfStream` if the end of stream has been reached.
+     * - `VkVideoQueueResult::Error` if an error occurs during frame retrieval.
      */
-    virtual int32_t  GetNextFrame(FrameDataType* pNewFrame, bool* endOfStream) = 0;
+    virtual VkVideoQueueResult GetNextFrame(FrameDataType* pNewFrame) = 0;
 
     /**
      * @brief Release a previously retrieved decoded frame.

--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -359,17 +359,16 @@ bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
 
         pLastDecodedFrame->Reset();
 
-        bool endOfStream = false;
-        int32_t numVideoFrames = 0;
-
-        numVideoFrames = m_videoQueue->GetNextFrame(pLastDecodedFrame, &endOfStream);
-        if (endOfStream && (numVideoFrames < 0)) {
+        VkVideoQueueResult result = m_videoQueue->GetNextFrame(pLastDecodedFrame);
+        if (result == VkVideoQueueResult::EndOfStream || result == VkVideoQueueResult::Error) {
             continueLoop = false;
             bool displayTimeNow = true;
             float fps = GetFrameRateFps(displayTimeNow);
             if (displayTimeNow) {
                 std::cout << "\t\tFrame " << m_frameCount << ", FPS: " << fps << std::endl;
             }
+        } else if (dumpDebug && result == VkVideoQueueResult::NoFrame) {
+            std::cout << "No frame available, waiting for more data" << std::endl;
         }
     }
 

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -33,7 +33,7 @@ public:
     virtual uint32_t GetProfileIdc() const;
     virtual VkFormat GetFrameImageFormat()  const;
     virtual VkExtent3D GetVideoExtent() const;
-    virtual int32_t GetNextFrame(VulkanDecodedFrame* pFrame, bool* endOfStream);
+    virtual VkVideoQueueResult GetNextFrame(VulkanDecodedFrame* pFrame);
     virtual int32_t ReleaseFrame(VulkanDecodedFrame* pDisplayedFrame);
 
     static VkSharedBaseObj<VulkanVideoProcessor>& invalidVulkanVideoProcessor;
@@ -67,7 +67,7 @@ public:
 
     int32_t ParserProcessNextDataChunk();
 
-    size_t OutputFrameToFile(VulkanDecodedFrame* pFrame);
+    bool OutputFrameToFile(VulkanDecodedFrame* pFrame, size_t* bytesWritten = nullptr);
     uint32_t Restart(int64_t& bitstreamOffset);
 
 private:

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -41,10 +41,10 @@ public:
     static VkResult Create(const DecoderConfig& settings, const VulkanDeviceContext* vkDevCtx,
                            VkSharedBaseObj<VulkanVideoProcessor>& vulkanVideoProcessor = invalidVulkanVideoProcessor);
 
-    int32_t Initialize(const VulkanDeviceContext* vkDevCtx,
-                       VkSharedBaseObj<VideoStreamDemuxer>& videoStreamDemuxer,
-                       VkSharedBaseObj<VkVideoFrameOutput>& frameToFile,
-                       DecoderConfig& programConfig);
+    VkResult Initialize(const VulkanDeviceContext* vkDevCtx,
+                        VkSharedBaseObj<VideoStreamDemuxer>& videoStreamDemuxer,
+                        VkSharedBaseObj<VkVideoFrameOutput>& frameToFile,
+                        DecoderConfig& programConfig);
 
     void Deinit();
 

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -158,7 +158,7 @@ int main(int argc, const char **argv)
         result = vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
         if (result != VK_SUCCESS) {
             fprintf(stderr, "Failed to initialize video processor\n");
-            if (IsVideoProfileNotSupportedError(result)) {
+            if (IsVideoUnsupportedResult(result)) {
                 return VVS_EXIT_UNSUPPORTED;
             }
             return EXIT_FAILURE;
@@ -243,7 +243,7 @@ int main(int argc, const char **argv)
         result = vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
         if (result != VK_SUCCESS) {
             fprintf(stderr, "Failed to initialize video processor\n");
-            if (IsVideoProfileNotSupportedError(result)) {
+            if (IsVideoUnsupportedResult(result)) {
                 return VVS_EXIT_UNSUPPORTED;
             }
             return EXIT_FAILURE;

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -155,11 +155,10 @@ int main(int argc, const char **argv)
             }
         }
 
-        int32_t initResult = vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
-        if (initResult != 0) {
+        result = vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
+        if (result != VK_SUCCESS) {
             fprintf(stderr, "Failed to initialize video processor\n");
-            // Check if the error indicates "unsupported" (negated VkResult values)
-            if (initResult < 0 && IsVideoProfileNotSupportedError(static_cast<VkResult>(-initResult))) {
+            if (IsVideoProfileNotSupportedError(result)) {
                 return VVS_EXIT_UNSUPPORTED;
             }
             return EXIT_FAILURE;
@@ -241,11 +240,10 @@ int main(int argc, const char **argv)
             }
         }
 
-        int32_t initResult = vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
-        if (initResult != 0) {
+        result = vulkanVideoProcessor->Initialize(&vkDevCtxt, videoStreamDemuxer, frameToFile, decoderConfig);
+        if (result != VK_SUCCESS) {
             fprintf(stderr, "Failed to initialize video processor\n");
-            // Check if the error indicates "unsupported" (negated VkResult values)
-            if (initResult < 0 && IsVideoProfileNotSupportedError(static_cast<VkResult>(-initResult))) {
+            if (IsVideoProfileNotSupportedError(result)) {
                 return VVS_EXIT_UNSUPPORTED;
             }
             return EXIT_FAILURE;

--- a/vk_video_decoder/src/vulkan_video_decoder.cpp
+++ b/vk_video_decoder/src/vulkan_video_decoder.cpp
@@ -44,9 +44,9 @@ public:
         return m_vulkanVideoProcessor->GetFrameImageFormat();
     }
 
-    virtual int32_t  GetNextFrame(VulkanDecodedFrame* pNewDecodedFrame, bool* endOfStream)
+    virtual VkVideoQueueResult GetNextFrame(VulkanDecodedFrame* pNewDecodedFrame)
     {
-        return m_vulkanVideoProcessor->GetNextFrame(pNewDecodedFrame, endOfStream);
+        return m_vulkanVideoProcessor->GetNextFrame(pNewDecodedFrame);
     }
 
     virtual int32_t  ReleaseFrame(VulkanDecodedFrame* pDoneDecodedFrame)

--- a/vk_video_decoder/src/vulkan_video_decoder.cpp
+++ b/vk_video_decoder/src/vulkan_video_decoder.cpp
@@ -222,14 +222,10 @@ VkResult VulkanVideoDecoderImpl::Initialize(VkInstance vkInstance,
         return result;
     }
 
-    int32_t initStatus = m_vulkanVideoProcessor->Initialize(&m_vkDevCtxt,
+    result = m_vulkanVideoProcessor->Initialize(&m_vkDevCtxt,
                                                             videoStreamDemuxer,
                                                             frameToFile,
                                                             m_decoderConfig);
-    if (initStatus != 0) {
-        return VK_ERROR_INITIALIZATION_FAILED;
-    }
-
     return result;
 }
 

--- a/vk_video_decoder/test/vulkan-video-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-dec/Main.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 
 #include "VkCodecUtils/DecoderConfig.h"
+#include "VkVSCommon.h"
 #include "vulkan_video_decoder.h"
 #include "VkVideoCore/VkVideoCoreProfile.h"
 #include "VkCodecUtils/VulkanFrame.h"
@@ -77,6 +78,9 @@ int main(int argc, const char** argv)
 
     if (result != VK_SUCCESS) {
         printf("Could not initialize the Vulkan decoder device!\n");
+        if (IsVideoUnsupportedResult(result)) {
+            return VVS_EXIT_UNSUPPORTED;
+        }
         return EXIT_FAILURE;
     }
 
@@ -126,7 +130,10 @@ int main(int argc, const char** argv)
                                               decoderConfig.verbose,
                                               decoderConfig.noDeviceFallback);
         if (result != VK_SUCCESS) {
-            assert(!"Can't initialize the Vulkan physical device!");
+            fprintf(stderr, "Can't initialize the Vulkan physical device!\n");
+            if (IsVideoUnsupportedResult(result)) {
+                return VVS_EXIT_UNSUPPORTED;
+            }
             return EXIT_FAILURE;
         }
         assert(displayShell->PhysDeviceCanPresent(vkDevCtxt.getPhysicalDevice(),
@@ -168,6 +175,9 @@ int main(int argc, const char** argv)
                                         vulkanVideoDecoder);
         if (result != VK_SUCCESS) {
             fprintf(stderr, "Error creating video decoder\n");
+            if (IsVideoUnsupportedResult(result)) {
+                return VVS_EXIT_UNSUPPORTED;
+            }
             return EXIT_FAILURE;
         }
 
@@ -194,7 +204,10 @@ int main(int argc, const char** argv)
                                               decoderConfig.verbose,
                                               decoderConfig.noDeviceFallback);
         if (result != VK_SUCCESS) {
-            assert(!"Can't initialize the Vulkan physical device!");
+            fprintf(stderr, "Can't initialize the Vulkan physical device!\n");
+            if (IsVideoUnsupportedResult(result)) {
+                return VVS_EXIT_UNSUPPORTED;
+            }
             return EXIT_FAILURE;
         }
 
@@ -210,7 +223,10 @@ int main(int argc, const char** argv)
                                               requestVideoComputeQueueMask != 0   // createComputeQueue
                                               );
         if (result != VK_SUCCESS) {
-            assert(!"Failed to create Vulkan device!");
+            fprintf(stderr, "Failed to create Vulkan device!\n");
+            if (IsVideoUnsupportedResult(result)) {
+                return VVS_EXIT_UNSUPPORTED;
+            }
             return EXIT_FAILURE;
         }
 
@@ -240,6 +256,9 @@ int main(int argc, const char** argv)
                                         vulkanVideoDecoder);
         if (result != VK_SUCCESS) {
             fprintf(stderr, "Error creating video decoder\n");
+            if (IsVideoUnsupportedResult(result)) {
+                return VVS_EXIT_UNSUPPORTED;
+            }
             return EXIT_FAILURE;
         }
 

--- a/vk_video_decoder/test/vulkan-video-simple-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-simple-dec/Main.cpp
@@ -157,6 +157,9 @@ int main(int argc, const char** argv)
                                       vulkanVideoDecoder);
     if (result != VK_SUCCESS) {
         fprintf(stderr, "Error creating video decoder\n");
+        if (IsVideoUnsupportedResult(result)) {
+            return VVS_EXIT_UNSUPPORTED;
+        }
         return EXIT_FAILURE;
     }
 

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -268,8 +268,11 @@ int main(int argc, char** argv)
                                                (encoderConfig->enablePreprocessComputeFilter == VK_TRUE))
                                               );
         if (result != VK_SUCCESS) {
-
-            assert(!"Failed to create Vulkan device!");
+            if (IsVideoUnsupportedResult(result)) {
+                printf("Failed to create Vulkan device: unsupported feature\n");
+                return VVS_EXIT_UNSUPPORTED;
+            }
+            printf("Failed to create Vulkan device!\n");
             return EXIT_FAILURE;
         }
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -201,7 +201,7 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
                                                          intraRefreshCapabilities);
     if (result != VK_SUCCESS) {
         // Distinguish between "not supported" and "actual error"
-        if (IsVideoProfileNotSupportedError(result)) {
+        if (IsVideoUnsupportedResult(result)) {
             // Not supported by hardware/driver - return VK_ERROR_INCOMPATIBLE_DRIVER
             std::cerr << "*** Video encode capabilities not supported by hardware/driver ("
                       << string_VkResult_Extended(result) << ") ***" << std::endl;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -404,7 +404,7 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
                                                                  intraRefreshCapabilities);
     if (result != VK_SUCCESS) {
         // Distinguish between "not supported" and "actual error"
-        if (IsVideoProfileNotSupportedError(result)) {
+        if (IsVideoUnsupportedResult(result)) {
             // Not supported by hardware/driver - return VK_ERROR_INCOMPATIBLE_DRIVER
             std::cerr << "*** Video encode capabilities not supported by hardware/driver ("
                       << string_VkResult_Extended(result) << ") ***" << std::endl;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -125,7 +125,7 @@ VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vk
                                                                  intraRefreshCapabilities);
     if (result != VK_SUCCESS) {
         // Distinguish between "not supported" and "actual error"
-        if (IsVideoProfileNotSupportedError(result)) {
+        if (IsVideoUnsupportedResult(result)) {
             // Not supported by hardware/driver - return VK_ERROR_INCOMPATIBLE_DRIVER
             std::cerr << "*** Video encode capabilities not supported by hardware/driver ("
                       << string_VkResult_Extended(result) << ") ***" << std::endl;

--- a/vk_video_encoder/test/vulkan-video-enc/Main.cpp
+++ b/vk_video_encoder/test/vulkan-video-enc/Main.cpp
@@ -27,6 +27,9 @@ int main(int argc, char** argv)
 
     if (result != VK_SUCCESS) {
         std::cerr << "Error creating the encoder instance: " << result << std::endl;
+        if (IsVideoUnsupportedResult(result)) {
+            return VVS_EXIT_UNSUPPORTED;
+        }
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
This PR improves error handling in the video decoder

VulkanVideoProcessor::Initialize now returns VkResult instead of int32_t, enabling proper Vulkan error propagation and avoid issue with -vkResult which was driving to confusion. Now use vkResult as in other init method of the code.

Fixes a bug where unsupported video dimensions weren't detected (negated VkResult codes became positive, always failing the < 0 check)