### PR TITLE
VulkanDeviceContext: move queue count validation before device check

### DIFF
--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -740,24 +740,24 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
                                                  bool createComputeQueue,
                                                  VkDevice vkDevice)
 {
+    if (numDecodeQueues < 0) {
+        numDecodeQueues = m_videoDecodeNumQueues;
+    } else {
+        numDecodeQueues = std::min(numDecodeQueues, m_videoDecodeNumQueues);
+    }
+
+    if (numEncodeQueues < 0) {
+        numEncodeQueues = m_videoEncodeNumQueues;
+    } else {
+        numEncodeQueues = std::min(numEncodeQueues, m_videoEncodeNumQueues);
+    }
+
     if (vkDevice == VK_NULL_HANDLE) {
         std::unordered_set<int32_t> uniqueQueueFamilies;
         VkDeviceCreateInfo devInfo = {};
         devInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
         devInfo.pNext = nullptr;
         devInfo.queueCreateInfoCount = 0;
-
-        if (numDecodeQueues < 0) {
-            numDecodeQueues = m_videoDecodeNumQueues;
-        } else {
-            numDecodeQueues = std::min(numDecodeQueues, m_videoDecodeNumQueues);
-        }
-
-        if (numEncodeQueues < 0) {
-            numEncodeQueues = m_videoEncodeNumQueues;
-        } else {
-            numEncodeQueues = std::min(numEncodeQueues, m_videoEncodeNumQueues);
-        }
 
         const int32_t maxQueueInstances = std::max(numDecodeQueues, numEncodeQueues);
         assert(maxQueueInstances <= MAX_QUEUE_INSTANCES);


### PR DESCRIPTION
Ensure numDecodeQueues/numEncodeQueues are resolved from -1 to actual counts before any device operations, not just when creating a new device.

This fixes the use of enableHWloadBalancing with the test app and not the demos app.

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 570.123.19 / Ubuntu 24.04.3 LTS

Total Tests:    70
Passed:         48
Crashed:         0
Failed:          0
Not Supported:   5
Skipped:        17 (in skip list)
Success Rate: 100.0%