### PR TITLE
VulkanAV1Decoder: fix SIGFPE crash by initializing picture decode dimensions

### DIFF
--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanAV1Decoder.cpp
@@ -295,6 +295,11 @@ bool VulkanAV1Decoder::BeginPicture(VkParserPictureData* pnvpd)
     // Allocate a buffer for the current picture
     if (m_pCurrPic == nullptr) {
         m_pClient->AllocPictureBuffer(&m_pCurrPic);
+        assert(m_pCurrPic);
+
+        m_pCurrPic->decodeWidth = frame_width;
+        m_pCurrPic->decodeHeight = frame_height;
+        m_pCurrPic->decodeSuperResWidth = upscaled_width;
     }
 
     pnvpd->PicWidthInMbs    = nvsi.nCodedWidth >> 4;
@@ -1196,6 +1201,7 @@ bool VulkanAV1Decoder::DecodeTileInfo()
         for (uint32_t off = 0, i = 0; off < sb_cols; off += tile_width_sb)
             pic_data->MiColStarts[i++] = off;
 
+        assert(tile_width_sb != 0);
         pic_data->tileInfo.TileCols = (sb_cols + tile_width_sb - 1) / tile_width_sb;
 
         min_log2_tile_rows = std::max(int(min_log2_tiles - log2_tile_cols), 0);
@@ -1210,6 +1216,7 @@ bool VulkanAV1Decoder::DecodeTileInfo()
         for (uint32_t off = 0, i = 0; off < sb_rows; off += tile_height_sb)
             pic_data->MiRowStarts[i++] = off;
 
+        assert(tile_height_sb != 0);
         pic_data->tileInfo.TileRows = (sb_rows + tile_height_sb - 1) / tile_height_sb;
 
         // Derive tile_width_in_sbs_minus_1 and tile_height_in_sbs_minus_1


### PR DESCRIPTION
## Description

When inter frames reference previous frames via `SetupFrameSizeWithRefs(),` the decoder reads dimensions from the reference buffer's `decodeWidth`, `decodeHeight`, and `decodeSuperResWidth` fields. These fields were never initialized, causing `frame_width=0`, which propagates to `tile_width_sb=0 `and triggers SIGFPE in `DecodeTileInfo()` during tile column calculation.

Set picture dimensions in `BeginPicture() `after allocation, consistent with VulkanVP9Decoder behavior.

## Type of change

bug fix

## Issue (optional)

Fixes #157.

## Tests

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.0.0-devel (git-57dc4cf4fb) / Ubuntu 24.04.3 LTS

Total Tests:    70
Passed:         43
Crashed:         0
Failed:          0
Not Supported:   1
Skipped:        26 (in skip list)
Success Rate: 100.0%

### Intel(R) UHD Graphics 770 (ADL-S GT1) / Intel open-source Mesa driver Mesa 26.0.0-devel (git-57dc4cf4fb) / Ubuntu 24.04.3 LTS

Total Tests:    70
Passed:         40
Crashed:         0
Failed:          0
Not Supported:   6
Skipped:        24 (in skip list)
Success Rate: 100.0%
