### PR TITLE
VkEncoderConfigH265: Fix CTB/TB size configuration based on device capabilities

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -28,14 +28,16 @@ struct EncoderConfigH265 : public EncoderConfig {
     enum { MAX_NUM_REF_PICS = 15 };
     enum { LOG2_MB_SIZE = 4 };
 
+    // represents (log2(size) - 3)
     enum CuSize
     {
         CU_SIZE_8x8   = 0U,
         CU_SIZE_16x16 = 1U,
         CU_SIZE_32x32 = 2U,
-        CU_SIZE_64x64 = 4U,
+        CU_SIZE_64x64 = 3U,
     };
 
+    // represents (log2(size) - 2)
     enum TransformUnitSize
     {
         TU_SIZE_4x4   = 0U,


### PR DESCRIPTION
## Description

To fix h265 encoding tests on ANV, need to fix the following:

- Fix incorrect CTB size enum value (64x64 was 4U, should be 3U)
- ~Initialize CTB and transform unit sizes to minimum values~
- ~Add methods to dynamically set CTB and TB sizes based on device capabilities~

This fixes encode_h265_default, encode_h265_main_profile and encode_h265_ip_gop tests which are marked as skipped on ANV.

## Type of change

bug fix

## Issue (optional)

H265 encoding doesn't work on ANV due to fence timeout.


## Tests

### NVIDIA GeForce RTX 4060 Ti / NVIDIA 580.94.14 / Ubuntu 22.04.5 LTS

Total Tests:    70
Passed:         51
Crashed:         0
Failed:          0
Not Supported:   1
Skipped:        18 (in skip list)
Success Rate: 100.0%

### Intel(R) UHD Graphics 770 (ADL-S GT1) / Intel open-source Mesa driver Mesa 26.1.0-devel (git-4d5a901d05) / Ubuntu 24.04.3 LTS

Total Tests:    70
Passed:         43
Crashed:         0
Failed:          0
Not Supported:   6
Skipped:        21 (in skip list)
Success Rate: 100.0%


### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.0-devel (git-464daaab90) / Ubuntu 24.04.3 LTS

Total Tests:    70
Passed:         51
Crashed:         0
Failed:          0
Not Supported:   1
Skipped:        18 (in skip list)
Success Rate: 100.0%

