### PR TITLE
encode: codec profile and level fixes

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -823,13 +823,15 @@ void EncoderConfig::InitVideoProfile()
         encodeBitDepthChroma = encodeBitDepthLuma;
     }
 
+    // Get the codec-specific profile (already set by InitProfileLevel)
+    uint32_t codecProfile = GetCodecProfile();
+
     // update the video profile
     videoCoreProfile = VkVideoCoreProfile::CreateEncodeProfile(
                                           codec, encodeChromaSubsampling,
                                           GetComponentBitDepthFlagBits(encodeBitDepthLuma),
                                           GetComponentBitDepthFlagBits(encodeBitDepthChroma),
-                                          (videoProfileIdc != (uint32_t)-1) ? videoProfileIdc :
-                                                  GetDefaultVideoProfileIdc(),
+                                          codecProfile,
                                           tuningMode);
 }
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -822,24 +822,14 @@ VkResult EncoderConfig::CreateCodecConfig(int argc, const char *argv[],
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void EncoderConfig::InitVideoProfile()
+VkVideoCoreProfile EncoderConfig::MakeVideoProfile(uint32_t codecProfile)
 {
-    if (encodeBitDepthLuma == 0) {
-        encodeBitDepthLuma = input.bpp;
-    }
-
-    if (encodeBitDepthChroma == 0) {
-        encodeBitDepthChroma = encodeBitDepthLuma;
-    }
-
-    // update the video profile
-    videoCoreProfile = VkVideoCoreProfile::CreateEncodeProfile(
-                                          codec, encodeChromaSubsampling,
-                                          GetComponentBitDepthFlagBits(encodeBitDepthLuma),
-                                          GetComponentBitDepthFlagBits(encodeBitDepthChroma),
-                                          (videoProfileIdc != (uint32_t)-1) ? videoProfileIdc :
-                                                  GetDefaultVideoProfileIdc(),
-                                          tuningMode);
+    return VkVideoCoreProfile::CreateEncodeProfile(
+                                    codec, encodeChromaSubsampling,
+                                    GetComponentBitDepthFlagBits(encodeBitDepthLuma),
+                                    GetComponentBitDepthFlagBits(encodeBitDepthChroma),
+                                    codecProfile,
+                                    tuningMode);
 }
 
 bool EncoderConfig::InitRateControl()

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -685,7 +685,6 @@ public:
     bool     noDeviceFallback;
     VkVideoCodecOperationFlagBitsKHR codec;
     bool useDpbArray;
-    uint32_t videoProfileIdc;
     uint32_t numInputImages;
     EncoderInputImageParameters input;
     uint8_t  encodeBitDepthLuma;
@@ -793,7 +792,6 @@ public:
     , noDeviceFallback(false)
     , codec(VK_VIDEO_CODEC_OPERATION_NONE_KHR)
     , useDpbArray(false)
-    , videoProfileIdc((uint32_t)-1)
     , numInputImages(DEFAULT_NUM_INPUT_IMAGES)
     , input()
     , encodeBitDepthLuma(0)
@@ -961,7 +959,8 @@ public:
     // These functions should be overwritten from the codec-specific classes
     virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) { return VK_ERROR_INITIALIZATION_FAILED; };
 
-    virtual uint32_t GetDefaultVideoProfileIdc() { return 0; };
+    // Returns the codec-specific profile identifier (must be set by InitProfileLevel first)
+    virtual uint32_t GetCodecProfile() = 0;
 
     virtual int8_t InitDpbCount() { return 16; };
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -973,6 +973,8 @@ public:
 
     virtual uint32_t GetDefaultVideoProfileIdc() { return 0; };
 
+    virtual bool DetermineLevelTier() = 0;
+
     virtual int8_t InitDpbCount() { return 16; };
 
     virtual bool InitRateControl();

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -695,7 +695,6 @@ public:
     bool     noDeviceFallback;
     VkVideoCodecOperationFlagBitsKHR codec;
     bool useDpbArray;
-    uint32_t videoProfileIdc;
     uint32_t numInputImages;
     EncoderInputImageParameters input;
     uint8_t  encodeBitDepthLuma;
@@ -803,7 +802,6 @@ public:
     , noDeviceFallback(false)
     , codec(VK_VIDEO_CODEC_OPERATION_NONE_KHR)
     , useDpbArray(false)
-    , videoProfileIdc((uint32_t)-1)
     , numInputImages(DEFAULT_NUM_INPUT_IMAGES)
     , input()
     , encodeBitDepthLuma(0)
@@ -925,7 +923,7 @@ public:
     // Factory Function
     static VkResult CreateCodecConfig(int argc, const char *argv[], VkSharedBaseObj<EncoderConfig>& encoderConfig);
 
-    void InitVideoProfile();
+    VkVideoCoreProfile MakeVideoProfile(uint32_t codecProfile);
 
     int ParseArguments(int argc, const char *argv[]);
 
@@ -965,13 +963,19 @@ public:
             return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
         }
 
+        if (encodeBitDepthLuma == 0) {
+            encodeBitDepthLuma = input.bpp;
+        }
+
+        if (encodeBitDepthChroma == 0) {
+            encodeBitDepthChroma = encodeBitDepthLuma;
+        }
+
         return VK_SUCCESS;
     }
 
     // These functions should be overwritten from the codec-specific classes
-    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) { return VK_ERROR_INITIALIZATION_FAILED; };
-
-    virtual uint32_t GetDefaultVideoProfileIdc() { return 0; };
+    virtual VkResult InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx) { return VK_ERROR_INITIALIZATION_FAILED; };
 
     virtual bool DetermineLevelTier() = 0;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -285,6 +285,29 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
     return VK_SUCCESS;
 }
 
+void EncoderConfigAV1::InitProfileLevel()
+{
+    // If profile hasn't been specified, determine it based on bit depth and chroma
+    if (profile == STD_VIDEO_AV1_PROFILE_INVALID) {
+        // PROFESSIONAL is required for 12-bit or 422
+        if ((input.bpp > 10) ||
+            (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR)) {
+            profile = STD_VIDEO_AV1_PROFILE_PROFESSIONAL;
+        }
+        // HIGH is required for 444 chroma
+        else if (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR) {
+            profile = STD_VIDEO_AV1_PROFILE_HIGH;
+        }
+        // MAIN supports 8-bit and 10-bit with 420
+        else {
+            profile = STD_VIDEO_AV1_PROFILE_MAIN;
+        }
+    }
+
+    // Determine level and tier based on encoder configuration
+    DetermineLevelTier();
+}
+
 int8_t EncoderConfigAV1::InitDpbCount()
 {
     dpbCount = STD_VIDEO_AV1_NUM_REF_FRAMES + 1; // BUFFER_POOL_MAX_SIZE = Number of frames in buffer pool = 10
@@ -351,8 +374,7 @@ bool EncoderConfigAV1::DetermineLevelTier()
 
 bool EncoderConfigAV1::InitRateControl()
 {
-    DetermineLevelTier();
-
+    // Level and tier are already initialized by InitProfileLevel()
     // use level max values for now. Limit it to 120Mbits/sec
     uint32_t levelBitrate = std::min(GetLevelBitrate(level, tier), 120000000u);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -199,8 +199,10 @@ bool EncoderConfigAV1::InitSequenceHeader(StdVideoAV1SequenceHeader *seqHdr,
     return true;
 }
 
-VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx)
+VkResult EncoderConfigAV1::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profile));
+
     const bool feedback2Requested = enablePictureFeedback || enablePixelCountFeedback ||
                                     enableSkippedPixelCountFeedback || enablePerPartitionFeedback;
     videoEncodeFeedback2Capabilities = VkVideoEncodeFeedback2CapabilitiesKHR

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -201,6 +201,24 @@ bool EncoderConfigAV1::InitSequenceHeader(StdVideoAV1SequenceHeader *seqHdr,
 
 VkResult EncoderConfigAV1::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    // If profile hasn't been specified, determine it based on bit depth and chroma subsampling
+    if (profile == STD_VIDEO_AV1_PROFILE_INVALID) {
+        // PROFESSIONAL is required for 12-bit or 422
+        if ((encodeBitDepthLuma > 10) ||
+            (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR)) {
+            profile = STD_VIDEO_AV1_PROFILE_PROFESSIONAL;
+        }
+        // HIGH is required for 444 chroma
+        else if (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR) {
+            profile = STD_VIDEO_AV1_PROFILE_HIGH;
+        }
+        // MAIN supports 8-bit and 10-bit with 420
+        else {
+            profile = STD_VIDEO_AV1_PROFILE_MAIN;
+        }
+    }
+
+    assert(profile != STD_VIDEO_AV1_PROFILE_INVALID);
     videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profile));
 
     const bool feedback2Requested = enablePictureFeedback || enablePixelCountFeedback ||

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -376,17 +376,14 @@ bool EncoderConfigAV1::DetermineLevelTier()
         }
     }
     if (lvl > STD_VIDEO_AV1_LEVEL_7_3) {
-        level = STD_VIDEO_AV1_LEVEL_7_3;
-        tier = 0;
+        return false;
     }
-
     return true;
 }
 
 bool EncoderConfigAV1::InitRateControl()
 {
-    DetermineLevelTier();
-
+    // Level and tier are already initialized by DetermineLevelTier()
     // use level max values for now. Limit it to 120Mbits/sec
     uint32_t levelBitrate = std::min(GetLevelBitrate(level, tier), 120000000u);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -102,6 +102,8 @@ struct EncoderConfigAV1 : public EncoderConfig {
         pic_height_in_sbs = DivUp<uint32_t>(encodeHeight, 16);
 
         if ((pic_width_in_sbs > 0) && (pic_height_in_sbs > 0)) {
+            // Initialize profile, level, and tier based on encoder configuration
+            InitProfileLevel();
             return VK_SUCCESS;
         }
 
@@ -110,6 +112,8 @@ struct EncoderConfigAV1 : public EncoderConfig {
     }
 
     virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
+
+    void InitProfileLevel();
 
     virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_AV1_PROFILE_MAIN; }
 
@@ -185,8 +189,8 @@ struct EncoderConfigAV1 : public EncoderConfig {
         return ((encodeWidth * encodeHeight * picSizeProfileFactor) >> 3);
     }
 
-    StdVideoAV1Profile                      profile{ STD_VIDEO_AV1_PROFILE_MAIN };
-    StdVideoAV1Level                        level{ STD_VIDEO_AV1_LEVEL_5_0 };
+    StdVideoAV1Profile                      profile{ STD_VIDEO_AV1_PROFILE_INVALID };
+    StdVideoAV1Level                        level{ STD_VIDEO_AV1_LEVEL_INVALID };
     uint8_t                                 tier{};
     VkVideoEncodeAV1CapabilitiesKHR         av1EncodeCapabilities{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR };
     VkVideoEncodeAV1QualityLevelPropertiesKHR av1QualityLevelProperties{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR };

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -115,7 +115,10 @@ struct EncoderConfigAV1 : public EncoderConfig {
 
     void InitProfileLevel();
 
-    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_AV1_PROFILE_MAIN; }
+    virtual uint32_t GetCodecProfile() override {
+        assert(profile != STD_VIDEO_AV1_PROFILE_INVALID);
+        return static_cast<uint32_t>(profile);
+    }
 
     virtual int8_t InitDpbCount() override;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -109,9 +109,7 @@ struct EncoderConfigAV1 : public EncoderConfig {
         return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
     }
 
-    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
-
-    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_AV1_PROFILE_MAIN; }
+    virtual VkResult InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
     virtual int8_t InitDpbCount() override;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -138,7 +138,7 @@ struct EncoderConfigAV1 : public EncoderConfig {
 
     bool ValidateLevel(uint32_t lLevel, uint32_t lTier);
 
-    bool DetermineLevelTier();
+    virtual bool DetermineLevelTier() override;
 
     uint32_t GetLevelMaxBitrate(uint32_t lLevel, uint32_t lTier) {
         if (lLevel < STD_VIDEO_AV1_LEVEL_4_0) {
@@ -186,7 +186,7 @@ struct EncoderConfigAV1 : public EncoderConfig {
     }
 
     StdVideoAV1Profile                      profile{ STD_VIDEO_AV1_PROFILE_MAIN };
-    StdVideoAV1Level                        level{ STD_VIDEO_AV1_LEVEL_5_0 };
+    StdVideoAV1Level                        level{ STD_VIDEO_AV1_LEVEL_INVALID };
     uint8_t                                 tier{};
     VkVideoEncodeAV1CapabilitiesKHR         av1EncodeCapabilities{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR };
     VkVideoEncodeAV1QualityLevelPropertiesKHR av1QualityLevelProperties{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR };

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -183,7 +183,7 @@ struct EncoderConfigAV1 : public EncoderConfig {
         return ((encodeWidth * encodeHeight * picSizeProfileFactor) >> 3);
     }
 
-    StdVideoAV1Profile                      profile{ STD_VIDEO_AV1_PROFILE_MAIN };
+    StdVideoAV1Profile                      profile{ STD_VIDEO_AV1_PROFILE_INVALID };
     StdVideoAV1Level                        level{ STD_VIDEO_AV1_LEVEL_INVALID };
     uint8_t                                 tier{};
     VkVideoEncodeAV1CapabilitiesKHR         av1EncodeCapabilities{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR };

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -63,6 +63,13 @@ StdVideoH264LevelIdc EncoderConfigH264::DetermineLevel(uint8_t dpbSize,
                                                        uint32_t _vbvBufferSize,
                                                        double frameRate)
 {
+    uint32_t cpbBrNalFactor = 1200;
+
+    // Adjust cpbBrNalFactor depending on whether the High (or greater) profile
+    // is being used
+    if (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH) {
+        cpbBrNalFactor = (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE) ? 4800 : 1500;
+    }
 
     uint32_t frameSizeInMbs = pic_width_in_mbs * pic_height_in_map_units;
     for (uint32_t idx = 0; idx < levelLimitsSize; idx++) {
@@ -71,8 +78,8 @@ StdVideoH264LevelIdc EncoderConfigH264::DetermineLevel(uint8_t dpbSize,
         if ((frameSizeInMbs) > ((uint32_t)levelLimits[idx].maxFS)) continue;
         if ((frameSizeInMbs * numRefFrames * 384) > levelLimits[idx].maxDPB * 1024) continue;
 
-        if ((bitrate != 0) && (bitrate > ((uint32_t)levelLimits[idx].maxBR * 1200))) continue;
-        if ((_vbvBufferSize != 0) && (_vbvBufferSize > ((uint32_t)levelLimits[idx].maxCPB * 1200))) continue;
+        if ((bitrate != 0) && (bitrate > ((uint32_t)levelLimits[idx].maxBR * cpbBrNalFactor))) continue;
+        if ((_vbvBufferSize != 0) && (_vbvBufferSize > ((uint32_t)levelLimits[idx].maxCPB * cpbBrNalFactor))) continue;
 
         return levelLimits[idx].level;
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -505,28 +505,18 @@ int8_t EncoderConfigH264::InitDpbCount()
 
     assert(pic_width_in_mbs > 0);
     assert(pic_height_in_map_units > 0);
-    uint32_t frameSizeInMbs = pic_width_in_mbs * pic_height_in_map_units;
 
     double frameRate = ((frameRateNumerator > 0) && (frameRateDenominator > 0))
                            ? (double)frameRateNumerator / frameRateDenominator
                            : (double)FRAME_RATE_NUM_DEFAULT / (double)FRAME_RATE_DEN_DEFAULT;
 
-    // WAR for super HD resolution (bypass H264 level check for frame mode and use level 5.2)
-    if ((frameSizeInMbs > ((uint32_t)levelLimits[levelLimitsSize - 1].maxFS) ||
-        ((frameSizeInMbs * frameRate) > ((uint32_t)levelLimits[levelLimitsSize - 1].maxMBPS)))) {
-        levelIdc = STD_VIDEO_H264_LEVEL_IDC_5_2;
-    } else {
-        // find lowest possible level
-        levelIdc = DetermineLevel(dpbCount, levelBitRate, vbvBufferSize, frameRate);
-    }
+    // find lowest possible level
+    levelIdc = DetermineLevel(dpbCount, levelBitRate, vbvBufferSize, frameRate);
 
     uint8_t levelDpbSize = (uint8_t)(((1024 * levelLimits[levelIdc].maxDPB)) /
                             ((pic_width_in_mbs * pic_height_in_map_units) * 384));
 
-    // XXX: If the level is 5.2, it is highly likely that we forced it to that
-    // value as a WAR for super HD. In that case, force the DPB size to
-    // DEFAULT_MAX_NUM_REF_FRAMES. Otherwise, clamp the computed DPB size to DEFAULT_MAX_NUM_REF_FRAMES.
-    levelDpbSize = (levelIdc == STD_VIDEO_H264_LEVEL_IDC_5_2) ? (uint8_t)DEFAULT_MAX_NUM_REF_FRAMES : std::min(uint8_t(DEFAULT_MAX_NUM_REF_FRAMES), levelDpbSize);
+    levelDpbSize = std::min(uint8_t(DEFAULT_MAX_NUM_REF_FRAMES), levelDpbSize);
 
     uint8_t dpbSize = (uint8_t)((dpbCount < 1) ? levelDpbSize : (uint8_t)(std::min((uint8_t)dpbCount, levelDpbSize))) + 1;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -310,11 +310,6 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
         sps->pic_order_cnt_type = STD_VIDEO_H264_POC_TYPE_2;
     }
 
-    // FIXME: Check if the HW supports transform_8x8_mode_is_supported
-    // based on capabilities or profiles supported
-    const bool transform_8x8_mode_is_supported = true;
-    const bool bIsFastestPreset = false;
-
     if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_ENABLE) {
         pps->flags.transform_8x8_mode_flag = true;
         if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_BASELINE) ||
@@ -326,12 +321,9 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
         pps->flags.transform_8x8_mode_flag = false;
     } else {
         // Autoselect
-        if (!bIsFastestPreset || transform_8x8_mode_is_supported) {
-            if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) ||
-                (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH)) {
-                // Unconditionally enable 8x8 transform
-                pps->flags.transform_8x8_mode_flag = true;
-            }
+        if (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH) {
+            // Unconditionally enable 8x8 transform
+            pps->flags.transform_8x8_mode_flag = true;
         }
     }
 
@@ -346,28 +338,6 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
 
     if (constrained_intra_pred_flag) {
         pps->flags.constrained_intra_pred_flag = true;
-    }
-
-    // If the profileIdc hasn't been specified, force set it now.
-    if (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) {
-        profileIdc = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
-
-        if (entropyCodingMode == ENTROPY_CODING_MODE_CABAC) {
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
-        }
-
-        if ((gopStructure.GetConsecutiveBFrameCount() > 0) || pps->flags.entropy_coding_mode_flag || !sps->flags.frame_mbs_only_flag)
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
-
-        if (pps->flags.transform_8x8_mode_flag) {
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH;
-        }
-
-        if ((sps->flags.qpprime_y_zero_transform_bypass_flag &&
-             (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR)) ||
-                (sps->chroma_format_idc == STD_VIDEO_H264_CHROMA_FORMAT_IDC_444)) {
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
-        }
     }
 
     sps->profile_idc = profileIdc;
@@ -491,14 +461,44 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
     return VK_SUCCESS;
 }
 
-int8_t EncoderConfigH264::InitDpbCount()
+void EncoderConfigH264::InitProfileLevel()
 {
-    dpbCount = 0; // TODO: What is the need for this?
+    // FIXME: Check if the HW supports transform_8x8_mode_is_supported
+    // based on capabilities or profiles supported
+    bool use8x8Transform = true;
 
-    // spsInfo->level represents the smallest level that we require for the
-    // given stream. This level constrains the maximum size (in terms of
-    // number of frames) that the DPB can have. levelDpbSize is this maximum
-    // value.
+    if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_ENABLE) {
+        use8x8Transform = true;
+    } else if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_DISABLE) {
+        use8x8Transform = false;
+    } else {
+        // Autoselect
+        if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) ||
+            (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH)) {
+            // Unconditionally enable 8x8 transform
+            use8x8Transform = true;
+        }
+    }
+
+    // If the profileIdc hasn't been specified, force set it now.
+    if (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) {
+        profileIdc = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
+
+        // Upgrade to MAIN profile if using B-frames or CABAC entropy coding
+        if ((gopStructure.GetConsecutiveBFrameCount() > 0) || (entropyCodingMode == ENTROPY_CODING_MODE_CABAC))
+            profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
+
+        if (use8x8Transform) {
+            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH;
+        }
+
+        // Upgrade to HIGH_444_PREDICTIVE for lossless encoding or 4:4:4 chroma
+        if ((tuningMode == VK_VIDEO_ENCODE_TUNING_MODE_LOSSLESS_KHR) ||
+            (input.chromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR)) {
+            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
+        }
+    }
+
     uint32_t levelBitRate = ((rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) && hrdBitrate == 0)
                                 ? averageBitrate // constrained by avg bitrate
                                 : hrdBitrate;  // constrained by max bitrate
@@ -512,6 +512,11 @@ int8_t EncoderConfigH264::InitDpbCount()
 
     // find lowest possible level
     levelIdc = DetermineLevel(dpbCount, levelBitRate, vbvBufferSize, frameRate);
+}
+
+int8_t EncoderConfigH264::InitDpbCount()
+{
+    dpbCount = 0; // TODO: What is the need for this?
 
     uint8_t levelDpbSize = (uint8_t)(((1024 * levelLimits[levelIdc].maxDPB)) /
                             ((pic_width_in_mbs * pic_height_in_map_units) * 384));

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -319,20 +319,11 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
     }
 
     if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_ENABLE) {
-        pps->flags.transform_8x8_mode_flag = true;
-        if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_BASELINE) ||
-            (profileIdc == STD_VIDEO_H264_PROFILE_IDC_MAIN)) {
-            fprintf(stderr, "The profile selected does not support transform_8x8_mode_flag, disabling it.\n");
-            pps->flags.transform_8x8_mode_flag = false;
-        }
-    } else if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_DISABLE) {
-        pps->flags.transform_8x8_mode_flag = false;
+        pps->flags.transform_8x8_mode_flag = (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH);
+        if (!pps->flags.transform_8x8_mode_flag)
+            fprintf(stderr, "The transform_8x8_mode_flag has been disabled because the selected profile does not support it.\n");
     } else {
-        // Autoselect
-        if (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH) {
-            // Unconditionally enable 8x8 transform
-            pps->flags.transform_8x8_mode_flag = true;
-        }
+        pps->flags.transform_8x8_mode_flag = false;
     }
 
     if (entropyCodingMode == ENTROPY_CODING_MODE_CABAC) {
@@ -454,14 +445,15 @@ VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceConte
         profileIdc = nextProfile;
     }
 
-    // For auto-selected profiles, refine feature flags based on actual hardware
-    // capabilities reported for the chosen profile.
-    if (autoSelected && (adaptiveTransformMode == ADAPTIVE_TRANSFORM_AUTOSELECT)) {
+    // If adaptiveTransformMode is AUTOSELECT, set it to either ENABLE or DISABLE
+    // based on hardware capabilities and the chosen profile, so that subsequent
+    // code using this parameter can take a simple binary decision.
+    if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_AUTOSELECT) {
         bool hwSupports8x8 = (h264EncodeCapabilities.stdSyntaxFlags &
                               VK_VIDEO_ENCODE_H264_STD_TRANSFORM_8X8_MODE_FLAG_SET_BIT_KHR) != 0;
-        if (!hwSupports8x8) {
-            adaptiveTransformMode = ADAPTIVE_TRANSFORM_DISABLE;
-        }
+        adaptiveTransformMode = (hwSupports8x8 && (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH))
+                                    ? ADAPTIVE_TRANSFORM_ENABLE
+                                    : ADAPTIVE_TRANSFORM_DISABLE;
     }
 
     if (verbose) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -398,8 +398,12 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
     return true;
 }
 
-VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx)
+VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    // If the profile has not been specified, fall back to HIGH.
+    videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(
+        profileIdc != STD_VIDEO_H264_PROFILE_IDC_INVALID ? profileIdc : STD_VIDEO_H264_PROFILE_IDC_HIGH));
+
     VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH264CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR,
                                                                           VkVideoEncodeH264QuantizationMapCapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUANTIZATION_MAP_CAPABILITIES_KHR>
                                                                 (vkDevCtx, videoCoreProfile,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -510,14 +510,8 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
     return VK_SUCCESS;
 }
 
-int8_t EncoderConfigH264::InitDpbCount()
+bool EncoderConfigH264::DetermineLevelTier()
 {
-    dpbCount = 0; // TODO: What is the need for this?
-
-    // spsInfo->level represents the smallest level that we require for the
-    // given stream. This level constrains the maximum size (in terms of
-    // number of frames) that the DPB can have. levelDpbSize is this maximum
-    // value.
     uint32_t levelBitRate = ((rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) && hrdBitrate == 0)
                                 ? averageBitrate // constrained by avg bitrate
                                 : hrdBitrate;  // constrained by max bitrate
@@ -531,6 +525,15 @@ int8_t EncoderConfigH264::InitDpbCount()
 
     // find lowest possible level
     levelIdc = DetermineLevel(dpbCount, levelBitRate, vbvBufferSize, frameRate);
+    if (levelIdc == STD_VIDEO_H264_LEVEL_IDC_INVALID) {
+        return false;
+    }
+    return (levelIdc <= h264EncodeCapabilities.maxLevelIdc);
+}
+
+int8_t EncoderConfigH264::InitDpbCount()
+{
+    dpbCount = 0; // TODO: What is the need for this?
 
     uint8_t levelDpbSize = (uint8_t)(((1024 * levelLimits[levelIdc].maxDPB)) /
                             ((pic_width_in_mbs * pic_height_in_map_units) * 384));

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -318,11 +318,6 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
         sps->pic_order_cnt_type = STD_VIDEO_H264_POC_TYPE_2;
     }
 
-    // FIXME: Check if the HW supports transform_8x8_mode_is_supported
-    // based on capabilities or profiles supported
-    const bool transform_8x8_mode_is_supported = true;
-    const bool bIsFastestPreset = false;
-
     if (adaptiveTransformMode == ADAPTIVE_TRANSFORM_ENABLE) {
         pps->flags.transform_8x8_mode_flag = true;
         if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_BASELINE) ||
@@ -334,12 +329,9 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
         pps->flags.transform_8x8_mode_flag = false;
     } else {
         // Autoselect
-        if (!bIsFastestPreset || transform_8x8_mode_is_supported) {
-            if ((profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) ||
-                (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH)) {
-                // Unconditionally enable 8x8 transform
-                pps->flags.transform_8x8_mode_flag = true;
-            }
+        if (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH) {
+            // Unconditionally enable 8x8 transform
+            pps->flags.transform_8x8_mode_flag = true;
         }
     }
 
@@ -354,28 +346,6 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
 
     if (constrained_intra_pred_flag) {
         pps->flags.constrained_intra_pred_flag = true;
-    }
-
-    // If the profileIdc hasn't been specified, force set it now.
-    if (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) {
-        profileIdc = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
-
-        if (entropyCodingMode == ENTROPY_CODING_MODE_CABAC) {
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
-        }
-
-        if ((gopStructure.GetConsecutiveBFrameCount() > 0) || pps->flags.entropy_coding_mode_flag || !sps->flags.frame_mbs_only_flag)
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
-
-        if (pps->flags.transform_8x8_mode_flag) {
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH;
-        }
-
-        if ((sps->flags.qpprime_y_zero_transform_bypass_flag &&
-             (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR)) ||
-                (sps->chroma_format_idc == STD_VIDEO_H264_CHROMA_FORMAT_IDC_444)) {
-            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
-        }
     }
 
     sps->profile_idc = profileIdc;
@@ -400,9 +370,32 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
 
 VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
-    // If the profile has not been specified, fall back to HIGH.
-    videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(
-        profileIdc != STD_VIDEO_H264_PROFILE_IDC_INVALID ? profileIdc : STD_VIDEO_H264_PROFILE_IDC_HIGH));
+    // If the profile was not specified by the user, select the highest profile
+    // required by the requested features.
+    if (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) {
+        // 8x8 transform support is hardware-dependent; it is verified after
+        // the capability query and the mode is adjusted accordingly.
+        bool use8x8Transform = (adaptiveTransformMode != ADAPTIVE_TRANSFORM_DISABLE);
+
+        profileIdc = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
+
+        // Upgrade to MAIN profile if using B-frames or CABAC entropy coding
+        if ((gopStructure.GetConsecutiveBFrameCount() > 0) || (entropyCodingMode == ENTROPY_CODING_MODE_CABAC))
+            profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
+
+        if (use8x8Transform) {
+            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH;
+        }
+
+        // Upgrade to HIGH_444_PREDICTIVE for lossless encoding or 4:4:4 chroma
+        if ((tuningMode == VK_VIDEO_ENCODE_TUNING_MODE_LOSSLESS_KHR) ||
+            (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR)) {
+            profileIdc = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
+        }
+    }
+
+    assert(profileIdc != STD_VIDEO_H264_PROFILE_IDC_INVALID);
+    videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profileIdc));
 
     VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH264CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR,
                                                                           VkVideoEncodeH264QuantizationMapCapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUANTIZATION_MAP_CAPABILITIES_KHR>

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -368,11 +368,23 @@ bool EncoderConfigH264::InitSpsPpsParameters(StdVideoH264SequenceParameterSet *s
     return true;
 }
 
+StdVideoH264ProfileIdc EncoderConfigH264::GetNextLowerProfile(StdVideoH264ProfileIdc profile)
+{
+    switch (profile) {
+    case STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE: return STD_VIDEO_H264_PROFILE_IDC_HIGH;
+    case STD_VIDEO_H264_PROFILE_IDC_HIGH:                return STD_VIDEO_H264_PROFILE_IDC_MAIN;
+    case STD_VIDEO_H264_PROFILE_IDC_MAIN:                return STD_VIDEO_H264_PROFILE_IDC_BASELINE;
+    default:                                             return STD_VIDEO_H264_PROFILE_IDC_INVALID;
+    }
+}
+
 VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
-    // If the profile was not specified by the user, select the highest profile
-    // required by the requested features.
-    if (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID) {
+    // Track whether the profile was user-specified or auto-selected.
+    const bool autoSelected = (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID);
+
+    if (autoSelected) {
+        // Select the highest profile required for the requested features.
         // 8x8 transform support is hardware-dependent; it is verified after
         // the capability query and the mode is adjusted accordingly.
         bool use8x8Transform = (adaptiveTransformMode != ADAPTIVE_TRANSFORM_DISABLE);
@@ -394,11 +406,26 @@ VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceConte
         }
     }
 
-    assert(profileIdc != STD_VIDEO_H264_PROFILE_IDC_INVALID);
-    videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profileIdc));
+    // Determine the minimum profile required by the content format.
+    StdVideoH264ProfileIdc minProfile = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
+    if ((tuningMode == VK_VIDEO_ENCODE_TUNING_MODE_LOSSLESS_KHR) ||
+        (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR)) {
+        minProfile = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
+    } else if (gopStructure.GetConsecutiveBFrameCount() > 0) {
+        minProfile = STD_VIDEO_H264_PROFILE_IDC_MAIN;
+    }
 
-    VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH264CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR,
-                                                                          VkVideoEncodeH264QuantizationMapCapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUANTIZATION_MAP_CAPABILITIES_KHR>
+    // Probe from the desired profile down to minProfile, stopping at the first
+    // profile the hardware accepts. If the profile was user-specified, a single
+    // probe is made and failure is reported without fallback.
+    VkResult result = VK_SUCCESS;
+
+    for (;;) {
+        assert(profileIdc != STD_VIDEO_H264_PROFILE_IDC_INVALID);
+        videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profileIdc));
+
+        result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH264CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR,
+                                                                     VkVideoEncodeH264QuantizationMapCapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUANTIZATION_MAP_CAPABILITIES_KHR>
                                                                 (vkDevCtx, videoCoreProfile,
                                                                  videoCapabilities,
                                                                  videoEncodeCapabilities,
@@ -406,17 +433,35 @@ VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceConte
                                                                  quantizationMapCapabilities,
                                                                  h264QuantizationMapCapabilities,
                                                                  intraRefreshCapabilities);
-    if (result != VK_SUCCESS) {
-        // Distinguish between "not supported" and "actual error"
-        if (IsVideoUnsupportedResult(result)) {
-            // Not supported by hardware/driver - return VK_ERROR_INCOMPATIBLE_DRIVER
-            std::cerr << "*** Video encode capabilities not supported by hardware/driver ("
-                      << VKVS_STRINGIFY(result) << ") ***" << std::endl;
+        if (result == VK_SUCCESS) {
+            break;
+        }
+
+        if (!IsVideoUnsupportedResult(result)) {
+            std::cerr << "*** Error getting video encode capabilities: " << VKVS_STRINGIFY(result) << " ***" << std::endl;
+            return result;
+        }
+
+        if (!autoSelected || (profileIdc == minProfile)) {
+            std::cerr << "*** H.264 profile " << profileIdc << " is not supported by the hardware/driver ***" << std::endl;
             return VK_ERROR_INCOMPATIBLE_DRIVER;
         }
-        // Actual error (e.g., out of memory)
-        std::cerr << "*** Error getting video capabilities: " << VKVS_STRINGIFY(result) << " ***" << std::endl;
-        return result;
+
+        StdVideoH264ProfileIdc nextProfile = GetNextLowerProfile(profileIdc);
+        if (verbose) {
+            std::cout << "H.264 profile " << profileIdc << " not supported, retrying with profile " << nextProfile << std::endl;
+        }
+        profileIdc = nextProfile;
+    }
+
+    // For auto-selected profiles, refine feature flags based on actual hardware
+    // capabilities reported for the chosen profile.
+    if (autoSelected && (adaptiveTransformMode == ADAPTIVE_TRANSFORM_AUTOSELECT)) {
+        bool hwSupports8x8 = (h264EncodeCapabilities.stdSyntaxFlags &
+                              VK_VIDEO_ENCODE_H264_STD_TRANSFORM_8X8_MODE_FLAG_SET_BIT_KHR) != 0;
+        if (!hwSupports8x8) {
+            adaptiveTransformMode = ADAPTIVE_TRANSFORM_DISABLE;
+        }
     }
 
     if (verbose) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -64,6 +64,13 @@ StdVideoH264LevelIdc EncoderConfigH264::DetermineLevel(uint8_t dpbSize,
                                                        uint32_t _vbvBufferSize,
                                                        double frameRate)
 {
+    uint32_t cpbBrNalFactor = 1200;
+
+    // Set cpbBrNalFactor depending on whether the High (or greater) profile is
+    // being used. See table A-2 in the H.264 specification.
+    if (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH) {
+        cpbBrNalFactor = (profileIdc >= STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE) ? 4800 : 1500;
+    }
 
     uint32_t frameSizeInMbs = pic_width_in_mbs * pic_height_in_map_units;
     for (uint32_t idx = 0; idx < levelLimitsSize; idx++) {
@@ -72,8 +79,8 @@ StdVideoH264LevelIdc EncoderConfigH264::DetermineLevel(uint8_t dpbSize,
         if ((frameSizeInMbs) > ((uint32_t)levelLimits[idx].maxFS)) continue;
         if ((frameSizeInMbs * numRefFrames * 384) > levelLimits[idx].maxDPB * 1024) continue;
 
-        if ((bitrate != 0) && (bitrate > ((uint32_t)levelLimits[idx].maxBR * 1200))) continue;
-        if ((_vbvBufferSize != 0) && (_vbvBufferSize > ((uint32_t)levelLimits[idx].maxCPB * 1200))) continue;
+        if ((bitrate != 0) && (bitrate > ((uint32_t)levelLimits[idx].maxBR * cpbBrNalFactor))) continue;
+        if ((_vbvBufferSize != 0) && (_vbvBufferSize > ((uint32_t)levelLimits[idx].maxCPB * cpbBrNalFactor))) continue;
 
         return levelLimits[idx].level;
     }
@@ -517,28 +524,18 @@ int8_t EncoderConfigH264::InitDpbCount()
 
     assert(pic_width_in_mbs > 0);
     assert(pic_height_in_map_units > 0);
-    uint32_t frameSizeInMbs = pic_width_in_mbs * pic_height_in_map_units;
 
     double frameRate = ((frameRateNumerator > 0) && (frameRateDenominator > 0))
                            ? (double)frameRateNumerator / frameRateDenominator
                            : (double)FRAME_RATE_NUM_DEFAULT / (double)FRAME_RATE_DEN_DEFAULT;
 
-    // WAR for super HD resolution (bypass H264 level check for frame mode and use level 5.2)
-    if ((frameSizeInMbs > ((uint32_t)levelLimits[levelLimitsSize - 1].maxFS) ||
-        ((frameSizeInMbs * frameRate) > ((uint32_t)levelLimits[levelLimitsSize - 1].maxMBPS)))) {
-        levelIdc = STD_VIDEO_H264_LEVEL_IDC_5_2;
-    } else {
-        // find lowest possible level
-        levelIdc = DetermineLevel(dpbCount, levelBitRate, vbvBufferSize, frameRate);
-    }
+    // find lowest possible level
+    levelIdc = DetermineLevel(dpbCount, levelBitRate, vbvBufferSize, frameRate);
 
     uint8_t levelDpbSize = (uint8_t)(((1024 * levelLimits[levelIdc].maxDPB)) /
                             ((pic_width_in_mbs * pic_height_in_map_units) * 384));
 
-    // XXX: If the level is 5.2, it is highly likely that we forced it to that
-    // value as a WAR for super HD. In that case, force the DPB size to
-    // DEFAULT_MAX_NUM_REF_FRAMES. Otherwise, clamp the computed DPB size to DEFAULT_MAX_NUM_REF_FRAMES.
-    levelDpbSize = (levelIdc == STD_VIDEO_H264_LEVEL_IDC_5_2) ? (uint8_t)DEFAULT_MAX_NUM_REF_FRAMES : std::min(uint8_t(DEFAULT_MAX_NUM_REF_FRAMES), levelDpbSize);
+    levelDpbSize = std::min(uint8_t(DEFAULT_MAX_NUM_REF_FRAMES), levelDpbSize);
 
     uint8_t dpbSize = (uint8_t)((dpbCount < 1) ? levelDpbSize : (uint8_t)(std::min((uint8_t)dpbCount, levelDpbSize))) + 1;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -90,23 +90,23 @@ struct EncoderConfigH264 : public EncoderConfig {
     {
             // Level limits (Table A-1)
             static const LevelLimits levelLimitsTbl[] = {
-                // level_idc, maxMBPS, maxFS, maxDPB,  maxBR, maxCPB, maxVmvR, prog, level
-                {10, 1485, 99, 148.5, 64, 175, 64, 1, STD_VIDEO_H264_LEVEL_IDC_1_0},
-                {11, 3000, 396, 337.5, 192, 500, 128, 1, STD_VIDEO_H264_LEVEL_IDC_1_1},
-                {12, 6000, 396, 891.0, 384, 1000, 128, 1, STD_VIDEO_H264_LEVEL_IDC_1_2},
-                {13, 11880, 396, 891.0, 768, 2000, 128, 1, STD_VIDEO_H264_LEVEL_IDC_1_3},
-                {20, 11880, 396, 891.0, 2000, 2000, 128, 1, STD_VIDEO_H264_LEVEL_IDC_2_0},
-                {21, 19800, 792, 1782.0, 4000, 4000, 256, 0, STD_VIDEO_H264_LEVEL_IDC_2_1},
-                {22, 20250, 1620, 3037.5, 4000, 4000, 256, 0, STD_VIDEO_H264_LEVEL_IDC_2_2},
-                {30, 40500, 1620, 3037.5, 10000, 10000, 256, 0, STD_VIDEO_H264_LEVEL_IDC_3_0},
-                {31, 108000, 3600, 6750.0, 14000, 14000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_3_1},
-                {32, 216000, 5120, 7680.0, 20000, 20000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_3_2},
-                {40, 245760, 8192, 12288.0, 20000, 25000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_4_0},
-                {41, 245760, 8192, 12288.0, 50000, 62500, 512, 0, STD_VIDEO_H264_LEVEL_IDC_4_1},
-                {42, 522240, 8704, 13056.0, 50000, 62500, 512, 0, STD_VIDEO_H264_LEVEL_IDC_4_2},
-                {50, 589824, 22080, 41400.0, 135000, 135000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_5_0},
-                {51, 983040, 36864, 69120.0, 240000, 240000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_5_1},
-                {52, 2073600, 36864, 69120.0, 240000, 240000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_5_2},
+            // level_idc, maxMBPS,   maxFS,    maxDPB,     maxBR,    maxCPB,  maxVmvR,  prog,    level
+                {10,         1485,      99,     148.5,        64,       175,       64,     1,    STD_VIDEO_H264_LEVEL_IDC_1_0},
+                {11,         3000,     396,     337.5,       192,       500,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_1_1},
+                {12,         6000,     396,     891.0,       384,      1000,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_1_2},
+                {13,        11880,     396,     891.0,       768,      2000,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_1_3},
+                {20,        11880,     396,     891.0,      2000,      2000,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_2_0},
+                {21,        19800,     792,    1782.0,      4000,      4000,      256,     0,    STD_VIDEO_H264_LEVEL_IDC_2_1},
+                {22,        20250,    1620,    3037.5,      4000,      4000,      256,     0,    STD_VIDEO_H264_LEVEL_IDC_2_2},
+                {30,        40500,    1620,    3037.5,     10000,     10000,      256,     0,    STD_VIDEO_H264_LEVEL_IDC_3_0},
+                {31,       108000,    3600,    6750.0,     14000,     14000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_3_1},
+                {32,       216000,    5120,    7680.0,     20000,     20000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_3_2},
+                {40,       245760,    8192,   12288.0,     20000,     25000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_4_0},
+                {41,       245760,    8192,   12288.0,     50000,     62500,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_4_1},
+                {42,       522240,    8704,   13056.0,     50000,     62500,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_4_2},
+                {50,       589824,   22080,   41400.0,    135000,    135000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_5_0},
+                {51,       983040,   36864,   69120.0,    240000,    240000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_5_1},
+                {52,      2073600,   36864,   69120.0,    240000,    240000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_5_2},
             };
 
             levelLimits = levelLimitsTbl;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -193,7 +193,10 @@ struct EncoderConfigH264 : public EncoderConfig {
 
     virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
-    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H264_PROFILE_IDC_HIGH; };
+    virtual uint32_t GetCodecProfile() override {
+        assert(profileIdc != STD_VIDEO_H264_PROFILE_IDC_INVALID);
+        return static_cast<uint32_t>(profileIdc);
+    }
 
     // 1. First h.264 determine the number of the Dpb buffers required
     virtual int8_t InitDpbCount() override;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -106,6 +106,9 @@ struct EncoderConfigH264 : public EncoderConfig {
                 {50,       589824,   22080,   41400.0,    135000,    135000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_0},
                 {51,       983040,   36864,   69120.0,    240000,    240000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_1},
                 {52,      2073600,   36864,   69120.0,    240000,    240000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_2},
+                {60,      4177920,  139264,  261120.0,    240000,    240000,     8192,  STD_VIDEO_H264_LEVEL_IDC_6_0},
+                {61,      8355840,  139264,  261120.0,    480000,    480000,     8192,  STD_VIDEO_H264_LEVEL_IDC_6_1},
+                {62,     16711680,  139264,  261120.0,    800000,    800000,     8192,  STD_VIDEO_H264_LEVEL_IDC_6_2},
             };
 
             levelLimits = levelLimitsTbl;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -54,7 +54,6 @@ struct EncoderConfigH264 : public EncoderConfig {
         uint32_t maxBR;      // 1200 bits/s
         uint32_t maxCPB;     // 1200 bits
         uint32_t maxVmvR;    // [-MaxVmvR..+MaxVmvR-0.25]
-        uint32_t prog;       // frame_mbs_only_flag = 1
         StdVideoH264LevelIdc level;
     };
 
@@ -90,23 +89,23 @@ struct EncoderConfigH264 : public EncoderConfig {
     {
             // Level limits (Table A-1)
             static const LevelLimits levelLimitsTbl[] = {
-            // level_idc, maxMBPS,   maxFS,    maxDPB,     maxBR,    maxCPB,  maxVmvR,  prog,    level
-                {10,         1485,      99,     148.5,        64,       175,       64,     1,    STD_VIDEO_H264_LEVEL_IDC_1_0},
-                {11,         3000,     396,     337.5,       192,       500,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_1_1},
-                {12,         6000,     396,     891.0,       384,      1000,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_1_2},
-                {13,        11880,     396,     891.0,       768,      2000,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_1_3},
-                {20,        11880,     396,     891.0,      2000,      2000,      128,     1,    STD_VIDEO_H264_LEVEL_IDC_2_0},
-                {21,        19800,     792,    1782.0,      4000,      4000,      256,     0,    STD_VIDEO_H264_LEVEL_IDC_2_1},
-                {22,        20250,    1620,    3037.5,      4000,      4000,      256,     0,    STD_VIDEO_H264_LEVEL_IDC_2_2},
-                {30,        40500,    1620,    3037.5,     10000,     10000,      256,     0,    STD_VIDEO_H264_LEVEL_IDC_3_0},
-                {31,       108000,    3600,    6750.0,     14000,     14000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_3_1},
-                {32,       216000,    5120,    7680.0,     20000,     20000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_3_2},
-                {40,       245760,    8192,   12288.0,     20000,     25000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_4_0},
-                {41,       245760,    8192,   12288.0,     50000,     62500,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_4_1},
-                {42,       522240,    8704,   13056.0,     50000,     62500,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_4_2},
-                {50,       589824,   22080,   41400.0,    135000,    135000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_5_0},
-                {51,       983040,   36864,   69120.0,    240000,    240000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_5_1},
-                {52,      2073600,   36864,   69120.0,    240000,    240000,      512,     0,    STD_VIDEO_H264_LEVEL_IDC_5_2},
+            // level_idc, maxMBPS,   maxFS,    maxDPB,     maxBR,    maxCPB,  maxVmvR,  level
+                {10,         1485,      99,     148.5,        64,       175,       64,  STD_VIDEO_H264_LEVEL_IDC_1_0},
+                {11,         3000,     396,     337.5,       192,       500,      128,  STD_VIDEO_H264_LEVEL_IDC_1_1},
+                {12,         6000,     396,     891.0,       384,      1000,      128,  STD_VIDEO_H264_LEVEL_IDC_1_2},
+                {13,        11880,     396,     891.0,       768,      2000,      128,  STD_VIDEO_H264_LEVEL_IDC_1_3},
+                {20,        11880,     396,     891.0,      2000,      2000,      128,  STD_VIDEO_H264_LEVEL_IDC_2_0},
+                {21,        19800,     792,    1782.0,      4000,      4000,      256,  STD_VIDEO_H264_LEVEL_IDC_2_1},
+                {22,        20250,    1620,    3037.5,      4000,      4000,      256,  STD_VIDEO_H264_LEVEL_IDC_2_2},
+                {30,        40500,    1620,    3037.5,     10000,     10000,      256,  STD_VIDEO_H264_LEVEL_IDC_3_0},
+                {31,       108000,    3600,    6750.0,     14000,     14000,      512,  STD_VIDEO_H264_LEVEL_IDC_3_1},
+                {32,       216000,    5120,    7680.0,     20000,     20000,      512,  STD_VIDEO_H264_LEVEL_IDC_3_2},
+                {40,       245760,    8192,   12288.0,     20000,     25000,      512,  STD_VIDEO_H264_LEVEL_IDC_4_0},
+                {41,       245760,    8192,   12288.0,     50000,     62500,      512,  STD_VIDEO_H264_LEVEL_IDC_4_1},
+                {42,       522240,    8704,   13056.0,     50000,     62500,      512,  STD_VIDEO_H264_LEVEL_IDC_4_2},
+                {50,       589824,   22080,   41400.0,    135000,    135000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_0},
+                {51,       983040,   36864,   69120.0,    240000,    240000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_1},
+                {52,      2073600,   36864,   69120.0,    240000,    240000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_2},
             };
 
             levelLimits = levelLimitsTbl;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -180,12 +180,16 @@ struct EncoderConfigH264 : public EncoderConfig {
         pic_height_in_map_units = DivUp<uint32_t>(encodeHeight, 16);
 
         if ((pic_width_in_mbs > 0) && (pic_height_in_map_units > 0)) {
+            // Initialize codec profile and level based on encoder configuration
+            InitProfileLevel();
             return VK_SUCCESS;
         }
 
         assert(!"Invalid pic_width_in_mbs and pic_height_in_map_units");
         return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
     }
+
+    void InitProfileLevel();
 
     virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -165,6 +165,9 @@ struct EncoderConfigH264 : public EncoderConfig {
                                         uint32_t vbvBufferSize,
                                         double frameRate);
 
+    // Returns the next lower profile in the H.264 hierarchy, or INVALID at the bottom.
+    static StdVideoH264ProfileIdc GetNextLowerProfile(StdVideoH264ProfileIdc profile);
+
     static void SetAspectRatio(StdVideoH264SequenceParameterSetVui *vui, int32_t width, int32_t height,
                                int32_t darWidth, int32_t darHeight);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -191,6 +191,8 @@ struct EncoderConfigH264 : public EncoderConfig {
 
     virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H264_PROFILE_IDC_HIGH; };
 
+    virtual bool DetermineLevelTier() override;
+
     // 1. First h.264 determine the number of the Dpb buffers required
     virtual int8_t InitDpbCount() override;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -187,11 +187,9 @@ struct EncoderConfigH264 : public EncoderConfig {
         return VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR;
     }
 
-    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
-
-    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H264_PROFILE_IDC_HIGH; };
-
     virtual bool DetermineLevelTier() override;
+
+    virtual VkResult InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
     // 1. First h.264 determine the number of the Dpb buffers required
     virtual int8_t InitDpbCount() override;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.h
@@ -54,7 +54,6 @@ struct EncoderConfigH264 : public EncoderConfig {
         uint32_t maxBR;      // 1200 bits/s
         uint32_t maxCPB;     // 1200 bits
         uint32_t maxVmvR;    // [-MaxVmvR..+MaxVmvR-0.25]
-        uint32_t prog;       // frame_mbs_only_flag = 1
         StdVideoH264LevelIdc level;
     };
 
@@ -90,23 +89,26 @@ struct EncoderConfigH264 : public EncoderConfig {
     {
             // Level limits (Table A-1)
             static const LevelLimits levelLimitsTbl[] = {
-                // level_idc, maxMBPS, maxFS, maxDPB,  maxBR, maxCPB, maxVmvR, prog, level
-                {10, 1485, 99, 148.5, 64, 175, 64, 1, STD_VIDEO_H264_LEVEL_IDC_1_0},
-                {11, 3000, 396, 337.5, 192, 500, 128, 1, STD_VIDEO_H264_LEVEL_IDC_1_1},
-                {12, 6000, 396, 891.0, 384, 1000, 128, 1, STD_VIDEO_H264_LEVEL_IDC_1_2},
-                {13, 11880, 396, 891.0, 768, 2000, 128, 1, STD_VIDEO_H264_LEVEL_IDC_1_3},
-                {20, 11880, 396, 891.0, 2000, 2000, 128, 1, STD_VIDEO_H264_LEVEL_IDC_2_0},
-                {21, 19800, 792, 1782.0, 4000, 4000, 256, 0, STD_VIDEO_H264_LEVEL_IDC_2_1},
-                {22, 20250, 1620, 3037.5, 4000, 4000, 256, 0, STD_VIDEO_H264_LEVEL_IDC_2_2},
-                {30, 40500, 1620, 3037.5, 10000, 10000, 256, 0, STD_VIDEO_H264_LEVEL_IDC_3_0},
-                {31, 108000, 3600, 6750.0, 14000, 14000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_3_1},
-                {32, 216000, 5120, 7680.0, 20000, 20000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_3_2},
-                {40, 245760, 8192, 12288.0, 20000, 25000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_4_0},
-                {41, 245760, 8192, 12288.0, 50000, 62500, 512, 0, STD_VIDEO_H264_LEVEL_IDC_4_1},
-                {42, 522240, 8704, 13056.0, 50000, 62500, 512, 0, STD_VIDEO_H264_LEVEL_IDC_4_2},
-                {50, 589824, 22080, 41400.0, 135000, 135000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_5_0},
-                {51, 983040, 36864, 69120.0, 240000, 240000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_5_1},
-                {52, 2073600, 36864, 69120.0, 240000, 240000, 512, 0, STD_VIDEO_H264_LEVEL_IDC_5_2},
+            // level_idc, maxMBPS,   maxFS,    maxDPB,     maxBR,    maxCPB,  maxVmvR,  level
+                {10,         1485,      99,     148.5,        64,       175,       64,  STD_VIDEO_H264_LEVEL_IDC_1_0},
+                {11,         3000,     396,     337.5,       192,       500,      128,  STD_VIDEO_H264_LEVEL_IDC_1_1},
+                {12,         6000,     396,     891.0,       384,      1000,      128,  STD_VIDEO_H264_LEVEL_IDC_1_2},
+                {13,        11880,     396,     891.0,       768,      2000,      128,  STD_VIDEO_H264_LEVEL_IDC_1_3},
+                {20,        11880,     396,     891.0,      2000,      2000,      128,  STD_VIDEO_H264_LEVEL_IDC_2_0},
+                {21,        19800,     792,    1782.0,      4000,      4000,      256,  STD_VIDEO_H264_LEVEL_IDC_2_1},
+                {22,        20250,    1620,    3037.5,      4000,      4000,      256,  STD_VIDEO_H264_LEVEL_IDC_2_2},
+                {30,        40500,    1620,    3037.5,     10000,     10000,      256,  STD_VIDEO_H264_LEVEL_IDC_3_0},
+                {31,       108000,    3600,    6750.0,     14000,     14000,      512,  STD_VIDEO_H264_LEVEL_IDC_3_1},
+                {32,       216000,    5120,    7680.0,     20000,     20000,      512,  STD_VIDEO_H264_LEVEL_IDC_3_2},
+                {40,       245760,    8192,   12288.0,     20000,     25000,      512,  STD_VIDEO_H264_LEVEL_IDC_4_0},
+                {41,       245760,    8192,   12288.0,     50000,     62500,      512,  STD_VIDEO_H264_LEVEL_IDC_4_1},
+                {42,       522240,    8704,   13056.0,     50000,     62500,      512,  STD_VIDEO_H264_LEVEL_IDC_4_2},
+                {50,       589824,   22080,   41400.0,    135000,    135000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_0},
+                {51,       983040,   36864,   69120.0,    240000,    240000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_1},
+                {52,      2073600,   36864,   69120.0,    240000,    240000,      512,  STD_VIDEO_H264_LEVEL_IDC_5_2},
+                {60,      4177920,  139264,  261120.0,    240000,    240000,     8192,  STD_VIDEO_H264_LEVEL_IDC_6_0},
+                {61,      8355840,  139264,  261120.0,    480000,    480000,     8192,  STD_VIDEO_H264_LEVEL_IDC_6_1},
+                {62,     16711680,  139264,  261120.0,    800000,    800000,     8192,  STD_VIDEO_H264_LEVEL_IDC_6_2},
             };
 
             levelLimits = levelLimitsTbl;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -513,15 +513,34 @@ StdVideoH265ProfileTierLevel EncoderConfigH265::GetLevelTier()
     return profileTierLevel;
 }
 
+void EncoderConfigH265::InitProfileLevel()
+{
+    // If profile hasn't been specified, determine it based on bit depth and chroma
+    if (profile == STD_VIDEO_H265_PROFILE_IDC_INVALID) {
+        if (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR) {
+            if (input.bpp == 8) {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN;
+            } else if (input.bpp <= 10) {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN_10;
+            } else {
+                profile = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
+            }
+        } else {
+            // 4:2:2 or 4:4:4 requires Range Extensions profile
+            profile = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
+        }
+    }
+
+    // Determine level and tier based on resolution, bitrate, etc.
+    StdVideoH265ProfileTierLevel profileTierLevel = GetLevelTier();
+    levelIdc = profileTierLevel.general_level_idc;
+    general_tier_flag = profileTierLevel.flags.general_tier_flag;
+}
+
 bool EncoderConfigH265::InitRateControl()
 {
-    StdVideoH265ProfileTierLevel profileTierLevel = GetLevelTier();
-    // Assigning default main profile if invalid.
-    if (profileTierLevel.general_profile_idc == STD_VIDEO_H265_PROFILE_IDC_INVALID) {
-        profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_MAIN;
-    }
-    uint32_t level = profileTierLevel.general_level_idc;
-    if (level >= levelLimitsTblSize) {
+    // Level is already initialized by InitProfileLevel()
+    if (levelIdc >= levelLimitsTblSize) {
         assert(!"The h.265 level index is invalid");
         return false;
     }
@@ -529,7 +548,7 @@ bool EncoderConfigH265::InitRateControl()
 
     // Safe default maximum bitrate
     uint32_t levelBitRate = std::max(averageBitrate, hrdBitrate);
-    levelBitRate = std::max(levelBitRate, std::min(levelLimits[level].maxBitRateMainTier * 800u, 120000000u));
+    levelBitRate = std::max(levelBitRate, std::min(levelLimits[levelIdc].maxBitRateMainTier * 800u, 120000000u));
 
     // If no bitrate is specified, use the level limit
     if (averageBitrate == 0) {
@@ -553,7 +572,7 @@ bool EncoderConfigH265::InitRateControl()
 
     // Use the main tier level limit for the max VBV buffer size, and no more than 8 seconds at peak rate
     if (vbvBufferSize == 0) {
-        vbvBufferSize = std::min(levelLimits[level].maxCPBSizeMainTier * cpbVclFactor, 100000000u);
+        vbvBufferSize = std::min(levelLimits[levelIdc].maxCPBSizeMainTier * cpbVclFactor, 100000000u);
         if (rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) {
             if ((vbvBufferSize >> 3) > hrdBitrate) {
                 vbvBufferSize = hrdBitrate << 3;
@@ -626,7 +645,9 @@ bool EncoderConfigH265::InitParamameters(VpsH265 *vpsInfo, SpsH265 *spsInfo,
         spsInfo->decPicBufMgr.max_num_reorder_pics[i] = gopStructure.GetConsecutiveBFrameCount() ? 1 : 0;
     }
 
-    spsInfo->profileTierLevel = GetLevelTier();
+    // Use pre-initialized profile, level, and tier from InitProfileLevel()
+    spsInfo->profileTierLevel.general_profile_idc = profile;
+    spsInfo->profileTierLevel.general_level_idc = levelIdc;
     spsInfo->profileTierLevel.flags.general_tier_flag = general_tier_flag;
 
     // Always insert profile tier flags assuming frame mode
@@ -635,21 +656,6 @@ bool EncoderConfigH265::InitParamameters(VpsH265 *vpsInfo, SpsH265 *spsInfo,
     spsInfo->profileTierLevel.flags.general_interlaced_source_flag = 0;
     spsInfo->profileTierLevel.flags.general_non_packed_constraint_flag = 0;
     spsInfo->profileTierLevel.flags.general_frame_only_constraint_flag = 1;
-
-    // Assigning default main profile if invalid.
-    if (spsInfo->profileTierLevel.general_profile_idc == STD_VIDEO_H265_PROFILE_IDC_INVALID) {
-        if (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR) {
-            if (input.bpp == 8) {
-                spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_MAIN;
-            } else if (input.bpp == 10) {
-                spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_MAIN_10;
-            } else {
-                spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
-            }
-        } else {
-            spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
-        }
-    }
 
     const uint32_t ctbLog2SizeY = cuSize + 3;
     const uint32_t minCbLog2SizeY = cuMinSize + 3;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -483,25 +483,24 @@ void EncoderConfigH265::InitializeSpsRefPicSet(SpsH265 *pSps)
     memset(&pSps->longTermRefPicsSps.lt_ref_pic_poc_lsb_sps, 0, sizeof(pSps->longTermRefPicsSps.lt_ref_pic_poc_lsb_sps));
 }
 
-StdVideoH265ProfileTierLevel EncoderConfigH265::GetLevelTier()
+void EncoderConfigH265::DetermineLevelTier()
 {
-    StdVideoH265ProfileTierLevel profileTierLevel{};
-    profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_INVALID;
-    profileTierLevel.general_level_idc = STD_VIDEO_H265_LEVEL_IDC_INVALID;
+    levelIdc = STD_VIDEO_H265_LEVEL_IDC_INVALID;
+    general_tier_flag = 0;
     uint32_t levelIdx = 0;
     for (; levelIdx < levelLimitsTblSize; levelIdx++) {
 
         if (IsSuitableLevel(levelIdx, 0)) {
-            profileTierLevel.general_level_idc = levelLimits[levelIdx].stdLevel;
-            profileTierLevel.flags.general_tier_flag = 0; // Main tier
+            levelIdc = levelLimits[levelIdx].stdLevel;
+            general_tier_flag = 0; // Main tier
             break;
         }
 
         if ((levelLimits[levelIdx].levelIdc >= 120) && // level 4.0 and above
             IsSuitableLevel(levelIdx, 1)) {
 
-            profileTierLevel.general_level_idc = levelLimits[levelIdx].stdLevel;
-            profileTierLevel.flags.general_tier_flag = 1; // Main tier
+            levelIdc = levelLimits[levelIdx].stdLevel;
+            general_tier_flag = 1; // High tier
             break;
         }
     }
@@ -509,8 +508,6 @@ StdVideoH265ProfileTierLevel EncoderConfigH265::GetLevelTier()
     if (levelIdx >= levelLimitsTblSize) {
         assert(!"No suitable level selected");
     }
-
-    return profileTierLevel;
 }
 
 void EncoderConfigH265::InitProfileLevel()
@@ -532,9 +529,7 @@ void EncoderConfigH265::InitProfileLevel()
     }
 
     // Determine level and tier based on resolution, bitrate, etc.
-    StdVideoH265ProfileTierLevel profileTierLevel = GetLevelTier();
-    levelIdc = profileTierLevel.general_level_idc;
-    general_tier_flag = profileTierLevel.flags.general_tier_flag;
+    DetermineLevelTier();
 }
 
 bool EncoderConfigH265::InitRateControl()

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -498,45 +498,38 @@ void EncoderConfigH265::InitializeSpsRefPicSet(SpsH265 *pSps)
     memset(&pSps->longTermRefPicsSps.lt_ref_pic_poc_lsb_sps, 0, sizeof(pSps->longTermRefPicsSps.lt_ref_pic_poc_lsb_sps));
 }
 
-StdVideoH265ProfileTierLevel EncoderConfigH265::GetLevelTier()
+bool EncoderConfigH265::DetermineLevelTier()
 {
-    StdVideoH265ProfileTierLevel profileTierLevel{};
-    profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_INVALID;
-    profileTierLevel.general_level_idc = STD_VIDEO_H265_LEVEL_IDC_INVALID;
+    levelIdc = STD_VIDEO_H265_LEVEL_IDC_INVALID;
+    general_tier_flag = 0;
     uint32_t levelIdx = 0;
     for (; levelIdx < levelLimitsTblSize; levelIdx++) {
 
         if (IsSuitableLevel(levelIdx, 0)) {
-            profileTierLevel.general_level_idc = levelLimits[levelIdx].stdLevel;
-            profileTierLevel.flags.general_tier_flag = 0; // Main tier
+            levelIdc = levelLimits[levelIdx].stdLevel;
+            general_tier_flag = 0; // Main tier
             break;
         }
 
         if ((levelLimits[levelIdx].levelIdc >= 120) && // level 4.0 and above
             IsSuitableLevel(levelIdx, 1)) {
 
-            profileTierLevel.general_level_idc = levelLimits[levelIdx].stdLevel;
-            profileTierLevel.flags.general_tier_flag = 1; // Main tier
+            levelIdc = levelLimits[levelIdx].stdLevel;
+            general_tier_flag = 1; // High tier
             break;
         }
     }
 
     if (levelIdx >= levelLimitsTblSize) {
-        assert(!"No suitable level selected");
+        return false;
     }
-
-    return profileTierLevel;
+    return (levelIdc <= h265EncodeCapabilities.maxLevelIdc);
 }
 
 bool EncoderConfigH265::InitRateControl()
 {
-    StdVideoH265ProfileTierLevel profileTierLevel = GetLevelTier();
-    // Assigning default main profile if invalid.
-    if (profileTierLevel.general_profile_idc == STD_VIDEO_H265_PROFILE_IDC_INVALID) {
-        profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_MAIN;
-    }
-    uint32_t level = profileTierLevel.general_level_idc;
-    if (level >= levelLimitsTblSize) {
+    // Level is already initialized by DetermineLevelTier()
+    if (levelIdc >= levelLimitsTblSize) {
         assert(!"The h.265 level index is invalid");
         return false;
     }
@@ -544,7 +537,7 @@ bool EncoderConfigH265::InitRateControl()
 
     // Safe default maximum bitrate
     uint32_t levelBitRate = std::max(averageBitrate, hrdBitrate);
-    levelBitRate = std::max(levelBitRate, std::min(levelLimits[level].maxBitRateMainTier * 800u, 120000000u));
+    levelBitRate = std::max(levelBitRate, std::min(levelLimits[levelIdc].maxBitRateMainTier * 800u, 120000000u));
 
     // If no bitrate is specified, use the level limit
     if (averageBitrate == 0) {
@@ -568,7 +561,7 @@ bool EncoderConfigH265::InitRateControl()
 
     // Use the main tier level limit for the max VBV buffer size, and no more than 8 seconds at peak rate
     if (vbvBufferSize == 0) {
-        vbvBufferSize = std::min(levelLimits[level].maxCPBSizeMainTier * cpbVclFactor, 100000000u);
+        vbvBufferSize = std::min(levelLimits[levelIdc].maxCPBSizeMainTier * cpbVclFactor, 100000000u);
         if (rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) {
             if ((vbvBufferSize >> 3) > hrdBitrate) {
                 vbvBufferSize = hrdBitrate << 3;
@@ -641,7 +634,9 @@ bool EncoderConfigH265::InitParamameters(VpsH265 *vpsInfo, SpsH265 *spsInfo,
         spsInfo->decPicBufMgr.max_num_reorder_pics[i] = gopStructure.GetConsecutiveBFrameCount() ? 1 : 0;
     }
 
-    spsInfo->profileTierLevel = GetLevelTier();
+    // Use pre-initialized profile, level, and tier from InitDeviceCapabilities() / DetermineLevelTier()
+    spsInfo->profileTierLevel.general_profile_idc = profile;
+    spsInfo->profileTierLevel.general_level_idc = levelIdc;
     spsInfo->profileTierLevel.flags.general_tier_flag = general_tier_flag;
 
     // Always insert profile tier flags assuming frame mode
@@ -650,21 +645,6 @@ bool EncoderConfigH265::InitParamameters(VpsH265 *vpsInfo, SpsH265 *spsInfo,
     spsInfo->profileTierLevel.flags.general_interlaced_source_flag = 0;
     spsInfo->profileTierLevel.flags.general_non_packed_constraint_flag = 0;
     spsInfo->profileTierLevel.flags.general_frame_only_constraint_flag = 1;
-
-    // Assigning default main profile if invalid.
-    if (spsInfo->profileTierLevel.general_profile_idc == STD_VIDEO_H265_PROFILE_IDC_INVALID) {
-        if (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR) {
-            if (input.bpp == 8) {
-                spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_MAIN;
-            } else if (input.bpp == 10) {
-                spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_MAIN_10;
-            } else {
-                spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
-            }
-        } else {
-            spsInfo->profileTierLevel.general_profile_idc = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
-        }
-    }
 
     const uint32_t ctbLog2SizeY = cuSize + 3;
     const uint32_t minCbLog2SizeY = cuMinSize + 3;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -112,8 +112,10 @@ int EncoderConfigH265::DoParseArguments(int argc, const char* argv[])
     return 0;
 }
 
-VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx)
+VkResult EncoderConfigH265::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profile));
+
     VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH265CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR,
                                                                           VkVideoEncodeH265QuantizationMapCapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUANTIZATION_MAP_CAPABILITIES_KHR>
                                                                 (vkDevCtx, videoCoreProfile,
@@ -634,7 +636,7 @@ bool EncoderConfigH265::InitParamameters(VpsH265 *vpsInfo, SpsH265 *spsInfo,
         spsInfo->decPicBufMgr.max_num_reorder_pics[i] = gopStructure.GetConsecutiveBFrameCount() ? 1 : 0;
     }
 
-    // Use pre-initialized profile, level, and tier from InitDeviceCapabilities() / DetermineLevelTier()
+    // Use pre-initialized profile, level, and tier from InitVideoProfileCapabilities() / DetermineLevelTier()
     spsInfo->profileTierLevel.general_profile_idc = profile;
     spsInfo->profileTierLevel.general_level_idc = levelIdc;
     spsInfo->profileTierLevel.flags.general_tier_flag = general_tier_flag;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -459,6 +459,17 @@ bool EncoderConfigH265::IsSuitableLevel(uint32_t levelIdx, bool highTier)
         return false;
     }
 
+    if (frameRateNumerator > 0 && frameRateDenominator > 0) {
+        double frameRate = (double)frameRateNumerator / frameRateDenominator;
+        if (picSizeInSamples * frameRate > levelLimits[levelIdx].maxLumaSr) {
+            return false;
+        }
+    }
+
+    // XXX: We currently don't check the DPB size as per Annex A.4.2 (max DPB pictures as a function of
+    // picture size relative to MaxLumaPS), as it is handled separately in VerifyDpbSize().
+    // This is fine because we don't allow the user to set the DPB size today.
+
     if (widthCtbAligned > (uint32_t)sqrt(levelLimits[levelIdx].maxLumaPS * 8.0)) {
         return false;
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -114,6 +114,23 @@ int EncoderConfigH265::DoParseArguments(int argc, const char* argv[])
 
 VkResult EncoderConfigH265::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    // If profile hasn't been specified, determine it based on bit depth and chroma subsampling
+    if (profile == STD_VIDEO_H265_PROFILE_IDC_INVALID) {
+        if (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR) {
+            if (encodeBitDepthLuma == 8) {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN;
+            } else if (encodeBitDepthLuma <= 10) {
+                profile = STD_VIDEO_H265_PROFILE_IDC_MAIN_10;
+            } else {
+                profile = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
+            }
+        } else {
+            // 4:2:2 or 4:4:4 requires Range Extensions profile
+            profile = STD_VIDEO_H265_PROFILE_IDC_FORMAT_RANGE_EXTENSIONS;
+        }
+    }
+
+    assert(profile != STD_VIDEO_H265_PROFILE_IDC_INVALID);
     videoCoreProfile = MakeVideoProfile(static_cast<uint32_t>(profile));
 
     VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeH265CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -197,7 +197,7 @@ struct EncoderConfigH265 : public EncoderConfig {
                           StdVideoH265SequenceParameterSetVui* vui = nullptr);
 
     bool IsSuitableLevel(uint32_t levelIdx, bool highTier);
-    StdVideoH265ProfileTierLevel GetLevelTier();
+    void DetermineLevelTier();
     void InitializeSpsRefPicSet(SpsH265 *pSps);
 
 };

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -83,8 +83,8 @@ struct EncoderConfigH265 : public EncoderConfig {
     size_t                 levelLimitsTblSize;
 
     EncoderConfigH265()
-      : profile(STD_VIDEO_H265_PROFILE_IDC_MAIN)
-      , levelIdc(STD_VIDEO_H265_LEVEL_IDC_5_2)
+      : profile(STD_VIDEO_H265_PROFILE_IDC_INVALID)
+      , levelIdc(STD_VIDEO_H265_LEVEL_IDC_INVALID)
       , h265EncodeCapabilities()
       , general_tier_flag(false)
       , numRefL0(1)
@@ -147,9 +147,15 @@ struct EncoderConfigH265 : public EncoderConfig {
         if (result != VK_SUCCESS) {
             return result;
         }
+
+        // Initialize profile, level, and tier based on encoder configuration
+        InitProfileLevel();
+
         // TODO: more h.265 parameters init ...
         return VK_SUCCESS;
     }
+
+    void InitProfileLevel();
 
     virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -159,7 +159,10 @@ struct EncoderConfigH265 : public EncoderConfig {
 
     virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
-    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H265_PROFILE_IDC_MAIN; };
+    virtual uint32_t GetCodecProfile() override {
+        assert(profile != STD_VIDEO_H265_PROFILE_IDC_INVALID);
+        return static_cast<uint32_t>(profile);
+    }
 
     // 1. First h.265 determine the number of the Dpb buffers required
     virtual int8_t InitDpbCount() override;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -149,13 +149,12 @@ struct EncoderConfigH265 : public EncoderConfig {
         if (result != VK_SUCCESS) {
             return result;
         }
+
         // TODO: more h.265 parameters init ...
         return VK_SUCCESS;
     }
 
-    virtual VkResult InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx) override;
-
-    virtual uint32_t GetDefaultVideoProfileIdc() override { return STD_VIDEO_H265_PROFILE_IDC_MAIN; };
+    virtual VkResult InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx) override;
 
     // 1. First h.265 determine the number of the Dpb buffers required
     virtual int8_t InitDpbCount() override;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -86,7 +86,7 @@ struct EncoderConfigH265 : public EncoderConfig {
 
     EncoderConfigH265()
       : profile(STD_VIDEO_H265_PROFILE_IDC_MAIN)
-      , levelIdc(STD_VIDEO_H265_LEVEL_IDC_5_2)
+      , levelIdc(STD_VIDEO_H265_LEVEL_IDC_INVALID)
       , h265EncodeCapabilities()
       , general_tier_flag(false)
       , numRefL0(1)
@@ -193,7 +193,7 @@ struct EncoderConfigH265 : public EncoderConfig {
                           StdVideoH265SequenceParameterSetVui* vui = nullptr);
 
     bool IsSuitableLevel(uint32_t levelIdx, bool highTier);
-    StdVideoH265ProfileTierLevel GetLevelTier();
+    virtual bool DetermineLevelTier() override;
     void InitializeSpsRefPicSet(SpsH265 *pSps);
 
 };

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.h
@@ -85,7 +85,7 @@ struct EncoderConfigH265 : public EncoderConfig {
     size_t                 levelLimitsTblSize;
 
     EncoderConfigH265()
-      : profile(STD_VIDEO_H265_PROFILE_IDC_MAIN)
+      : profile(STD_VIDEO_H265_PROFILE_IDC_INVALID)
       , levelIdc(STD_VIDEO_H265_LEVEL_IDC_INVALID)
       , h265EncodeCapabilities()
       , general_tier_flag(false)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -816,6 +816,11 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
         return result;
     }
 
+    if (!encoderConfig->DetermineLevelTier()) {
+        std::cerr << "Failed to determine a suitable level for the given encoding parameters" << std::endl;
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
     if (encoderConfig->verbose) {
         const VkVideoCapabilitiesKHR& vidCaps = encoderConfig->videoCapabilities;
         const VkVideoEncodeCapabilitiesKHR& encCaps = encoderConfig->videoEncodeCapabilities;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -807,12 +807,9 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
 
     m_encoderConfig = encoderConfig;
 
-    // Update the video profile
-    encoderConfig->InitVideoProfile();
-
-    result = encoderConfig->InitDeviceCapabilities(m_vkDevCtx);
+    result = encoderConfig->InitVideoProfileCapabilities(m_vkDevCtx);
     if (result != VK_SUCCESS) {
-        std::cerr << "InitDeviceCapabilties failed" << std::endl;
+        std::cerr << "InitVideoProfileCapabilities failed" << std::endl;
         return result;
     }
 
@@ -974,7 +971,7 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
 
     // Reconfigure the gopStructure structure because the device may not support
     // specific GOP structure. For example it may not support B-frames.
-    // gopStructure.Init() should be called after  encoderConfig->InitDeviceCapabilities().
+    // gopStructure.Init() should be called after encoderConfig->InitVideoProfileCapabilities().
     m_encoderConfig->gopStructure.Init(m_encoderConfig->numFrames);
     if (encoderConfig->GetMaxBFrameCount() < m_encoderConfig->gopStructure.GetConsecutiveBFrameCount()) {
         if (m_encoderConfig->verbose) {


### PR DESCRIPTION
## Description

This series of commits refactors the code related to the determination of the codec profile and level (and tier, as applicable) for all codecs, to avoid redundant calculations / storage and to provide a single point early in the encoder initialization stage where these values are decided.

Another effect of this refactoring is to use the proper codec profile when creating the video profile used for queries of capabilities and recommended settings. Previously, the video profile constructed for these purposes used a default codec profile, which may not be representative of (or may not support) the coding tools requested.

## Type of change

Bug fixes and refactoring

## Tests

### NVIDIA L2 / NVIDIA 580.94.17 / Ubuntu 24.04.3 LTS

Total Tests:    70
Passed:         50
Crashed:         0
Failed:          0
Not Supported:   2
Skipped:        18 (in skip list)
Success Rate: 100.0%


## Additional Details (optional)

Prior to this series of commits, running the test framework would show 1 unsupported test case, and 51 passing test cases. The unsupported test case was `encode_h265_main10_profile`, which is actually supported by the NVIDIA driver. The list of passing tests included `encode_av1_high_profile` and `encode_av1_professional_profile` although these profiles are not supported.

With the current changes, `encode_av1_high_profile` and `encode_av1_professional_profile` are correctly marked as unsupported and `encode_h265_main10_profile` executes successfully.