### PR TITLE
common: do not modify output filename

### DIFF
--- a/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
+++ b/common/libs/VkCodecUtils/VkVideoFrameToFile.cpp
@@ -209,21 +209,16 @@ public:
             m_outputFile = nullptr;
         }
 
-        std::string fileNameWithModExt;
         // Check if the file does not have a y4m extension,
         // but y4m format is requested.
         if (y4mFormat && !hasExtension(fileName, ".y4m")) {
             std::cout << std::endl << "y4m output format is requested, ";
             std::cout << "but the output file's (" << fileName << ") extension isn't .y4m!"
                       << std::endl;
-            fileNameWithModExt = fileName + std::string(".y4m");
-            fileName = fileNameWithModExt.c_str();
         } else if ((y4mFormat == false) && !hasExtension(fileName, ".yuv")) {
             std::cout << std::endl << "Raw yuv output format is requested, ";
             std::cout << "but the output file's (" << fileName << ") extension isn't .yuv!"
                       << std::endl;
-            fileNameWithModExt = fileName + std::string(".yuv");
-            fileName = fileNameWithModExt.c_str();
         }
 
         if (fileName != nullptr) {


### PR DESCRIPTION




## Description

just inform user that the output filename is not correct but do not modify it.

**The previous change was breaking fluster use.**

## Type of change

bug fix

## Issue (optional)



## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.1.0-devel (git-889cf429ee) / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  14
Skipped:         5 (in skip list)
Success Rate: 100.0%

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  14
Skipped:         2 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
