### PR TITLE
cmake: add logic to download ffmpeg for win32

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
   Vulkan-Video-Samples-win:
     strategy:
       matrix:
-        platform: [windows-x64, windows-x64-clang, windows-x64-ffmpeg, windows-x86, windows-x86-clang, win-arm64]
+        platform: [windows-x64, windows-x64-clang, windows-x64-without-ffmpeg, windows-x86, windows-x86-clang, win-arm64]
         include:
           - platform: windows-x64
             arch: x64
@@ -210,16 +210,19 @@ jobs:
             arch: x64
             cmake_arch: x64
             toolset: ClangCL
-          - platform: windows-x64-ffmpeg
+          - platform: windows-x64-without-ffmpeg
             arch: x64
             cmake_arch: x64
+            extra_cmake_flags: -DDOWNLOAD_FFMPEG=OFF
           - platform: windows-x86
             arch: x86
             cmake_arch: Win32
+            extra_cmake_flags: -DDOWNLOAD_FFMPEG=OFF
           - platform: windows-x86-clang
             arch: x86
             cmake_arch: Win32
             toolset: ClangCL
+            extra_cmake_flags: -DDOWNLOAD_FFMPEG=OFF
           - platform: win-arm64
             arch: arm64
             cmake_arch: ARM64
@@ -243,31 +246,6 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install FFmpeg
-        if: matrix.platform == 'windows-x64-ffmpeg'
-        run: |
-          # Define the custom installation location
-          $currentDir = pwd
-          $finalDestination = "$currentDir\vk_video_decoder\bin\libs\ffmpeg\win64"
-          echo $finalDestination
-
-          # Create the directory
-          New-Item -ItemType Directory -Force -Path $finalDestination
-
-          # Download FFmpeg static build
-          Invoke-WebRequest -Uri https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip -OutFile ffmpeg.zip
-
-          # Extract FFmpeg to the tmp location
-          $tempExtractPath = "$currentDir\temp\extracted"
-
-          # Extract the entire archive to a temporary folder
-          Expand-Archive -Path ffmpeg.zip -DestinationPath $tempExtractPath -Force
-          Get-ChildItem -Path $tempExtractPath\ffmpeg-master-latest-win64-gpl-shared
-
-          # Get the contents of the first folder in the archive
-          Get-ChildItem -Path $tempExtractPath\ffmpeg-master-latest-win64-gpl-shared | Where-Object { $_.PSIsContainer } | Copy-Item -Destination $finalDestination -Force -Recurse
-          echo "$finalDestination\bin" | Out-File -Encoding ASCII -Append $env:GITHUB_PATH
-
       - name: Build Debug
         shell: bash
         run: |
@@ -275,6 +253,7 @@ jobs:
           cd BUILD_DEBUG
           cmake -DCMAKE_GENERATOR_PLATFORM=${{ matrix.cmake_arch }} \
             ${{ matrix.toolset && format('-T {0}', matrix.toolset) || '' }} \
+            ${{ matrix.extra_cmake_flags || '' }} \
             -DCMAKE_BUILD_TYPE=Debug ..
           cmake --build . --parallel $BUILD_JOBS --config Debug
 
@@ -285,6 +264,7 @@ jobs:
             pushd BUILD_RELEASE
             cmake -DCMAKE_GENERATOR_PLATFORM=${{ matrix.cmake_arch }} \
               ${{ matrix.toolset && format('-T {0}', matrix.toolset) || '' }} \
+              ${{ matrix.extra_cmake_flags || '' }} \
               -DCMAKE_BUILD_TYPE=Release ..
             cmake --build . --parallel $BUILD_JOBS --config Release
             mkdir release-artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
     runs-on: ${{ matrix.os || 'windows-latest' }}
     strategy:
       matrix:
-        platform: [windows-x64, windows-x64-clang, windows-x64-ffmpeg, windows-x86, windows-x86-clang, win-arm64]
+        platform: [windows-x64, windows-x64-clang, windows-x64-without-ffmpeg, windows-x86, windows-x86-clang, win-arm64]
         include:
           - platform: windows-x64
             arch: x64
@@ -211,16 +211,19 @@ jobs:
             arch: x64
             cmake_arch: x64
             toolset: ClangCL
-          - platform: windows-x64-ffmpeg
+          - platform: windows-x64-without-ffmpeg
             arch: x64
             cmake_arch: x64
+            extra_cmake_flags: -DDOWNLOAD_FFMPEG=OFF
           - platform: windows-x86
             arch: x86
             cmake_arch: Win32
+            extra_cmake_flags: -DDOWNLOAD_FFMPEG=OFF
           - platform: windows-x86-clang
             arch: x86
             cmake_arch: Win32
             toolset: ClangCL
+            extra_cmake_flags: -DDOWNLOAD_FFMPEG=OFF
           - platform: win-arm64
             os: windows-11-arm
             arch: arm64
@@ -244,31 +247,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install FFmpeg
-        if: matrix.platform == 'windows-x64-ffmpeg'
-        run: |
-          # Define the custom installation location
-          $currentDir = pwd
-          $finalDestination = "$currentDir\vk_video_decoder\bin\libs\ffmpeg\win64"
-          echo $finalDestination
-
-          # Create the directory
-          New-Item -ItemType Directory -Force -Path $finalDestination
-
-          # Download FFmpeg static build
-          Invoke-WebRequest -Uri https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip -OutFile ffmpeg.zip
-
-          # Extract FFmpeg to the tmp location
-          $tempExtractPath = "$currentDir\temp\extracted"
-
-          # Extract the entire archive to a temporary folder
-          Expand-Archive -Path ffmpeg.zip -DestinationPath $tempExtractPath -Force
-          Get-ChildItem -Path $tempExtractPath\ffmpeg-master-latest-win64-gpl-shared
-
-          # Get the contents of the first folder in the archive
-          Get-ChildItem -Path $tempExtractPath\ffmpeg-master-latest-win64-gpl-shared | Where-Object { $_.PSIsContainer } | Copy-Item -Destination $finalDestination -Force -Recurse
-          echo "$finalDestination\bin" | Out-File -Encoding ASCII -Append $env:GITHUB_PATH
-
       - name: Build Debug
         shell: bash
         run: |
@@ -276,6 +254,7 @@ jobs:
           cd BUILD_DEBUG
           cmake -DCMAKE_GENERATOR_PLATFORM=${{ matrix.cmake_arch }} \
             ${{ matrix.toolset && format('-T {0}', matrix.toolset) || '' }} \
+            ${{ matrix.extra_cmake_flags || '' }} \
             -DCMAKE_BUILD_TYPE=Debug ..
           cmake --build . --parallel $BUILD_JOBS --config Debug
 
@@ -286,6 +265,7 @@ jobs:
             pushd BUILD_RELEASE
             cmake -DCMAKE_GENERATOR_PLATFORM=${{ matrix.cmake_arch }} \
               ${{ matrix.toolset && format('-T {0}', matrix.toolset) || '' }} \
+              ${{ matrix.extra_cmake_flags || '' }} \
               -DCMAKE_BUILD_TYPE=Release ..
             cmake --build . --parallel $BUILD_JOBS --config Release
             mkdir release-artifacts

--- a/BUILD.md
+++ b/BUILD.md
@@ -61,17 +61,20 @@ Windows 10 or Windows 11 with the following software packages:
 - [Vulkan SDK](https://vulkan.lunarg.com/sdk/home#windows)
   - Install current Vulkan SDK (i.e. VulkanSDK-1.4.304.0-Installer.exe or later)
   - Make sure to install the the correct SDK for the targeted system arch - x86_64 or ARM64
-- [FFMPEG libraries for Windows]
-  - Download the latest version of the FFMPEG shared libraries archive from https://github.com/BtbN/FFmpeg-Builds/releases
-  - The archive must have the following pattern in the name: For Windows x86_64 ffmpeg-*-win64-*-shared.zip
-  - Example download link:
-         For Windows x86_64 https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip
-         For Windows ARM64  https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip
+- FFMPEG libraries (ONLY for Windows)
+  - FFmpeg is downloaded automatically during CMake configuration from https://github.com/BtbN/FFmpeg-Builds/releases
+  - The download is skipped if the libraries are already present in `vk_video_decoder\bin\libs\ffmpeg\<platform>\lib`
+  - To disable automatic download, pass `-DDOWNLOAD_FFMPEG=OFF` to CMake
+  - To download manually instead before the CMake configure, get the version of the FFMPEG shared libraries archive from any desired source.
+    - Example download link:
+         - For Windows x86_64 https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip
+         - For Windows ARM64  https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip
   - Extract to <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg
-  - Verify that <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\win64\bin or <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\winarm64\bin contains:
+  - Verify that <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\win64\bin or <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\winarm64\bin contains the required DLLs:
     - avformat-59.dll
     - avutil-59.dll
     - avcodec-59.dll
+    - Note: the version might be different since the latest release is downloaded
   - Verify that <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\win64\lib or <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\winarm64\lib contains the corresponding .lib files
 
 ### Windows Build Commands

--- a/BUILD.md
+++ b/BUILD.md
@@ -71,9 +71,9 @@ Windows 10 or Windows 11 with the following software packages:
          - For Windows ARM64  https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip
   - Extract to <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg
   - Verify that <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\win64\bin or <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\winarm64\bin contains the required DLLs:
-    - avformat-59.dll
-    - avutil-59.dll
-    - avcodec-59.dll
+    - avformat-62.dll
+    - avutil-60.dll
+    - avcodec-62.dll
     - Note: the version might be different since the latest release is downloaded
   - Verify that <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\win64\lib or <APP_INSTALLED_LOC>\vk_video_decoder\bin\libs\ffmpeg\winarm64\lib contains the corresponding .lib files
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ if(BUILD_DECODER OR USE_ENCODER_SHADERC)
     include(FindShaderc)
 endif()
 
+if(WIN32)
+    option(DOWNLOAD_FFMPEG "Automatically download FFmpeg for Windows builds" ON)
+endif()
+
 ############ VULKAN_FFMPEG_LIB_PATH ######################################
 if (DEFINED ENV{VULKAN_FFMPEG_LIB_DIR_PATH})
     MESSAGE(STATUS "VULKAN_FFMPEG_LIB_DIR_PATH ENV VAR is set to $ENV{VULKAN_FFMPEG_LIB_DIR_PATH}")

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -7,6 +7,52 @@
 # FFMPEG_ROOT, if this module use this path to find FFMPEG headers
 # and libraries.
 
+if(WIN32 AND DOWNLOAD_FFMPEG)
+    set(FFMPEG_BTBN_TAG        "autobuild-2026-03-31-13-11")
+    set(FFMPEG_BTBN_REVISION   "n8.1-7-ga3475e2554")
+    set(FFMPEG_BTBN_SUFFIX     "8.1")
+    set(FFMPEG_WIN64_SHA256    "6093603479c4bf6f14268d399a46f9ce2d050cce0a9f5e4ed81af2ac373e367b")
+    set(FFMPEG_WINARM64_SHA256 "055fd2c58a01042e9da66bfa046c8aa3fa7ea69b9d60fa82bfc9a1a96fc694a0")
+
+    if(CMAKE_GENERATOR_PLATFORM MATCHES "^(aarch64|arm64|ARM64)")
+        set(FFMPEG_PLATFORM_DIR "winarm64")
+        set(FFMPEG_EXPECTED_HASH "${FFMPEG_WINARM64_SHA256}")
+    else()
+        set(FFMPEG_PLATFORM_DIR "win64")
+        set(FFMPEG_EXPECTED_HASH "${FFMPEG_WIN64_SHA256}")
+    endif()
+
+    set(FFMPEG_ARCHIVE_NAME "ffmpeg-${FFMPEG_BTBN_REVISION}-${FFMPEG_PLATFORM_DIR}-lgpl-shared-${FFMPEG_BTBN_SUFFIX}")
+    set(FFMPEG_DOWNLOAD_URL "https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BTBN_TAG}/${FFMPEG_ARCHIVE_NAME}.zip")
+    set(FFMPEG_DEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vk_video_decoder/bin/libs/ffmpeg/${FFMPEG_PLATFORM_DIR}")
+
+    file(GLOB FFMPEG_EXISTING_LIBS "${FFMPEG_DEST_DIR}/lib/avcodec*.lib")
+    if(FFMPEG_EXISTING_LIBS)
+        message(STATUS "FFmpeg libraries already present in ${FFMPEG_DEST_DIR}")
+    else()
+        message(STATUS "FFmpeg libraries not found in ${FFMPEG_DEST_DIR}")
+        message(STATUS "Downloading FFmpeg from ${FFMPEG_DOWNLOAD_URL} ...")
+
+        include(FetchContent)
+        FetchContent_Declare(
+            ffmpeg_prebuilt
+            URL                        "${FFMPEG_DOWNLOAD_URL}"
+            URL_HASH                   "SHA256=${FFMPEG_EXPECTED_HASH}"
+            TLS_VERIFY                 ON
+            DOWNLOAD_EXTRACT_TIMESTAMP FALSE
+        )
+        FetchContent_MakeAvailable(ffmpeg_prebuilt)
+
+        foreach(SUBDIR bin lib include)
+            if(EXISTS "${ffmpeg_prebuilt_SOURCE_DIR}/${SUBDIR}")
+                file(COPY "${ffmpeg_prebuilt_SOURCE_DIR}/${SUBDIR}/" DESTINATION "${FFMPEG_DEST_DIR}/${SUBDIR}")
+            endif()
+        endforeach()
+
+        message(STATUS "FFmpeg libraries installed to ${FFMPEG_DEST_DIR}")
+    endif()
+endif()
+
 # Macro to find header and lib directories
 # example: FFMPEG_FIND(AVFORMAT avformat avformat.h)
 MACRO(FFMPEG_FIND varname shortname headername)

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -7,6 +7,56 @@
 # FFMPEG_ROOT, if this module use this path to find FFMPEG headers
 # and libraries.
 
+if(WIN32)
+    option(DOWNLOAD_FFMPEG "Automatically download FFmpeg for Windows builds" ON)
+endif()
+
+if(WIN32 AND DOWNLOAD_FFMPEG)
+    set(FFMPEG_BTBN_TAG        "autobuild-2026-03-31-13-11")
+    set(FFMPEG_BTBN_REVISION   "n8.1-7-ga3475e2554")
+    set(FFMPEG_BTBN_SUFFIX     "8.1")
+    set(FFMPEG_WIN64_SHA256    "6093603479c4bf6f14268d399a46f9ce2d050cce0a9f5e4ed81af2ac373e367b")
+    set(FFMPEG_WINARM64_SHA256 "055fd2c58a01042e9da66bfa046c8aa3fa7ea69b9d60fa82bfc9a1a96fc694a0")
+
+    if(CMAKE_GENERATOR_PLATFORM MATCHES "^(aarch64|arm64|ARM64)")
+        set(FFMPEG_PLATFORM_DIR "winarm64")
+        set(FFMPEG_EXPECTED_HASH "${FFMPEG_WINARM64_SHA256}")
+    else()
+        set(FFMPEG_PLATFORM_DIR "win64")
+        set(FFMPEG_EXPECTED_HASH "${FFMPEG_WIN64_SHA256}")
+    endif()
+
+    set(FFMPEG_ARCHIVE_NAME "ffmpeg-${FFMPEG_BTBN_REVISION}-${FFMPEG_PLATFORM_DIR}-lgpl-shared-${FFMPEG_BTBN_SUFFIX}")
+    set(FFMPEG_DOWNLOAD_URL "https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BTBN_TAG}/${FFMPEG_ARCHIVE_NAME}.zip")
+    set(FFMPEG_DEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vk_video_decoder/bin/libs/ffmpeg/${FFMPEG_PLATFORM_DIR}")
+
+    file(GLOB FFMPEG_EXISTING_LIBS "${FFMPEG_DEST_DIR}/lib/avcodec*.lib")
+    if(FFMPEG_EXISTING_LIBS)
+        message(STATUS "FFmpeg libraries already present in ${FFMPEG_DEST_DIR}")
+    else()
+        message(STATUS "FFmpeg libraries not found in ${FFMPEG_DEST_DIR}")
+        message(STATUS "Downloading FFmpeg from ${FFMPEG_DOWNLOAD_URL} ...")
+
+        include(FetchContent)
+        FetchContent_Declare(
+            ffmpeg_prebuilt
+            URL                        "${FFMPEG_DOWNLOAD_URL}"
+            URL_HASH                   "SHA256=${FFMPEG_EXPECTED_HASH}"
+            TLS_VERIFY                 ON
+            DOWNLOAD_EXTRACT_TIMESTAMP FALSE
+        )
+        FetchContent_MakeAvailable(ffmpeg_prebuilt)
+
+        foreach(SUBDIR bin lib include)
+            if(EXISTS "${ffmpeg_prebuilt_SOURCE_DIR}/${SUBDIR}")
+                file(COPY "${ffmpeg_prebuilt_SOURCE_DIR}/${SUBDIR}/" DESTINATION "${FFMPEG_DEST_DIR}/${SUBDIR}")
+            endif()
+        endforeach()
+
+        message(STATUS "FFmpeg libraries installed to ${FFMPEG_DEST_DIR}")
+    endif()
+endif()
+
 # Macro to find header and lib directories
 # example: FFMPEG_FIND(AVFORMAT avformat avformat.h)
 MACRO(FFMPEG_FIND varname shortname headername)

--- a/vk_video_decoder/bin/libs/ffmpeg/win64/download-ffmpeg-from.txt
+++ b/vk_video_decoder/bin/libs/ffmpeg/win64/download-ffmpeg-from.txt
@@ -1,1 +1,0 @@
- https://github.com/BtbN/FFmpeg-Builds/releases/download


### PR DESCRIPTION
## Description

Currently, using FFmpeg on Windows requires manual installation.

This patch adds a cmake module that downloads FFmpeg shared libraries for Windows when they are not already present. Pre-built LGPL binaries are fetched from BtbN/FFmpeg-Builds for win64 and winarm64 platforms, and verified against published SHA256 checksums.

The automatic download can be disabled with `-DDOWNLOAD_FFMPEG=OFF`.

## Type of change

feature

## Tests

### AMD Radeon RX 6600 (1002:73ff) / AMD proprietary driver 26.8.1 (AMD proprietary shader compiler) / Windows 10

Total Tests:    88
Passed:         37
Crashed:         7
Failed:          2
Not Supported:  42
Success Rate: 80.4%

### Intel(R) UHD Graphics 770 (ADL-S GT1) (8086:4680) / Intel open-source Mesa driver Mesa 26.3.0-devel (git-fe1491b758) / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  25
Skipped:         3 (in skip list)
Success Rate: 100.0%

### AMD Radeon RX 7600 (RADV NAVI33) (1002:7480) / radv Mesa 26.3.0-devel (git-fe1491b758) / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         69
Crashed:         0
Failed:          0
Not Supported:  12
Skipped:         4 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

For AMD proprietary driver for Windows, 7 tests crash and 2 fail, same behavior as with the main branch.
