### PR TITLE
decode: populate the profile pictureLayout according to the media parsing with h264 contents

### DIFF
--- a/common/include/VkVideoCore/VkVideoCoreProfile.h
+++ b/common/include/VkVideoCore/VkVideoCoreProfile.h
@@ -84,13 +84,25 @@ public:
         VkVideoComponentBitDepthFlagsKHR chromaBitDepth,
         uint32_t codecProfileIdc)
     {
-        // AV1 must use CreateDecodeAV1Profile to carry filmGrainSupport.
-        assert((videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR) ||
-               (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR) ||
+        // AV1 and H264 have dedicated factory methods.
+        assert((videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR) ||
                (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_VP9_BIT_KHR));
         VkVideoCoreProfile profile = MakeBaseProfile(videoCodecOperation, chromaSubsampling,
                                                      lumaBitDepth, chromaBitDepth);
-        profile.InitDecodeProfile(videoCodecOperation, codecProfileIdc);
+        profile.InitDecodeProfile(codecProfileIdc);
+        return profile;
+    }
+    static VkVideoCoreProfile CreateDecodeH264Profile(
+        VkVideoChromaSubsamplingFlagsKHR chromaSubsampling,
+        VkVideoComponentBitDepthFlagsKHR lumaBitDepth,
+        VkVideoComponentBitDepthFlagsKHR chromaBitDepth,
+        uint32_t codecProfileIdc,
+        VkVideoDecodeH264PictureLayoutFlagBitsKHR h264PictureLayout)
+    {
+        VkVideoCoreProfile profile = MakeBaseProfile(VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR,
+                                                     chromaSubsampling, lumaBitDepth, chromaBitDepth);
+        profile.InitDecodeProfile(codecProfileIdc);
+        profile.m_h264DecodeProfile.pictureLayout = h264PictureLayout;
         return profile;
     }
 
@@ -103,7 +115,7 @@ public:
     {
         VkVideoCoreProfile profile = MakeBaseProfile(VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR,
                                                      chromaSubsampling, lumaBitDepth, chromaBitDepth);
-        profile.InitDecodeProfile(VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR, codecProfileIdc);
+        profile.InitDecodeProfile(codecProfileIdc);
         profile.m_av1DecodeProfile.filmGrainSupport = filmGrainSupport ? VK_TRUE : VK_FALSE;
         return profile;
     }
@@ -121,7 +133,7 @@ public:
                (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR));
         VkVideoCoreProfile profile = MakeBaseProfile(videoCodecOperation, chromaSubsampling,
                                                      lumaBitDepth, chromaBitDepth);
-        profile.InitEncodeProfile(videoCodecOperation, codecProfileIdc, tuningMode);
+        profile.InitEncodeProfile(codecProfileIdc, tuningMode);
         return profile;
     }
 
@@ -663,7 +675,7 @@ private:
                 //  Use default ext profile parameters
                 m_h264DecodeProfile.sType         = VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR;
                 m_h264DecodeProfile.stdProfileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
-                m_h264DecodeProfile.pictureLayout = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_KHR;
+                m_h264DecodeProfile.pictureLayout = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR;
             }
             m_profile.pNext = &m_h264DecodeProfile;
             m_h264DecodeProfile.pNext = NULL;
@@ -781,8 +793,7 @@ private:
         return true;
     }
 
-    void InitDecodeProfile(VkVideoCodecOperationFlagBitsKHR videoCodecOperation,
-                           uint32_t codecProfileIdc)
+    void InitDecodeProfile(uint32_t codecProfileIdc)
     {
         VkVideoDecodeH264ProfileInfoKHR decodeH264ProfilesRequest;
         VkVideoDecodeH265ProfileInfoKHR decodeH265ProfilesRequest;
@@ -790,15 +801,15 @@ private:
         VkVideoDecodeVP9ProfileInfoKHR  decodeVP9ProfilesRequest;
         VkBaseInStructure* pVideoProfileExt = NULL;
 
-        if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR) {
+        if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR) {
             decodeH264ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR;
             decodeH264ProfilesRequest.pNext = NULL;
             decodeH264ProfilesRequest.stdProfileIdc = (codecProfileIdc == 0) ?
                                                        STD_VIDEO_H264_PROFILE_IDC_INVALID :
                                                        (StdVideoH264ProfileIdc)codecProfileIdc;
-            decodeH264ProfilesRequest.pictureLayout = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_KHR;
+            decodeH264ProfilesRequest.pictureLayout = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR;
             pVideoProfileExt = (VkBaseInStructure*)&decodeH264ProfilesRequest;
-        } else if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR) {
+        } else if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR) {
             decodeAV1ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PROFILE_INFO_KHR;
             decodeAV1ProfilesRequest.pNext = nullptr;
             switch (codecProfileIdc) {
@@ -813,14 +824,14 @@ private:
             decodeAV1ProfilesRequest.stdProfile = (StdVideoAV1Profile)codecProfileIdc;
             decodeAV1ProfilesRequest.filmGrainSupport = VK_FALSE;
             pVideoProfileExt = (VkBaseInStructure*)&decodeAV1ProfilesRequest;
-        } else if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR) {
+        } else if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR) {
             decodeH265ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR;
             decodeH265ProfilesRequest.pNext = NULL;
             decodeH265ProfilesRequest.stdProfileIdc = (codecProfileIdc == 0) ?
                                                        STD_VIDEO_H265_PROFILE_IDC_INVALID :
                                                        (StdVideoH265ProfileIdc)codecProfileIdc;
             pVideoProfileExt = (VkBaseInStructure*)&decodeH265ProfilesRequest;
-        } else if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_VP9_BIT_KHR) {
+        } else if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_DECODE_VP9_BIT_KHR) {
             decodeVP9ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_PROFILE_INFO_KHR;
             decodeVP9ProfilesRequest.pNext = NULL;
             decodeVP9ProfilesRequest.stdProfile = (codecProfileIdc == 0) ?
@@ -835,8 +846,7 @@ private:
         PopulateProfileExt(pVideoProfileExt);
     }
 
-    void InitEncodeProfile(VkVideoCodecOperationFlagBitsKHR videoCodecOperation,
-                           uint32_t codecProfileIdc,
+    void InitEncodeProfile(uint32_t codecProfileIdc,
                            VkVideoEncodeTuningModeKHR tuningMode)
     {
         VkVideoEncodeH264ProfileInfoKHR encodeH264ProfilesRequest;
@@ -848,21 +858,21 @@ private:
                                                          NULL, 0, 0, tuningMode};
         VkBaseInStructure* pEncodeUsageInfo = (VkBaseInStructure*)&encodeUsageInfoRequest;
 
-        if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR) {
+        if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR) {
             encodeH264ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR;
             encodeH264ProfilesRequest.pNext = pEncodeUsageInfo;
             encodeH264ProfilesRequest.stdProfileIdc = (codecProfileIdc == 0) ?
                                                        STD_VIDEO_H264_PROFILE_IDC_INVALID :
                                                        (StdVideoH264ProfileIdc)codecProfileIdc;
             pVideoProfileExt = (VkBaseInStructure*)&encodeH264ProfilesRequest;
-        } else if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR) {
+        } else if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR) {
             encodeH265ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR;
             encodeH265ProfilesRequest.pNext = pEncodeUsageInfo;
             encodeH265ProfilesRequest.stdProfileIdc = (codecProfileIdc == 0) ?
                                                        STD_VIDEO_H265_PROFILE_IDC_INVALID :
                                                        (StdVideoH265ProfileIdc)codecProfileIdc;
             pVideoProfileExt = (VkBaseInStructure*)&encodeH265ProfilesRequest;
-        } else if (videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR) {
+        } else if (m_profile.videoCodecOperation == VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR) {
             encodeAV1ProfilesRequest.sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PROFILE_INFO_KHR;
             encodeAV1ProfilesRequest.pNext = pEncodeUsageInfo;
             encodeAV1ProfilesRequest.stdProfile = (codecProfileIdc == 0) ?

--- a/vk_video_decoder/libs/VkDecoderUtils/FFmpegDemuxer.cpp
+++ b/vk_video_decoder/libs/VkDecoderUtils/FFmpegDemuxer.cpp
@@ -404,7 +404,12 @@ public:
                     case STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE:
                         break;
                     default:
-                        std::cerr << "\nInvalid h.264 profile: " << profile << std::endl;
+                        // Unknown/invalid H.264 profile from FFmpeg (e.g., profile=0 for
+                        // some streams). Default to High which is a superset of all lower
+                        // profiles and handles Baseline/Main/interlaced content correctly.
+                        std::cerr << "WARNING: Unknown H.264 profile_idc=" << profile
+                                  << " from demuxer, defaulting to HIGH (100)" << std::endl;
+                        return STD_VIDEO_H264_PROFILE_IDC_HIGH;
                 }
             }
             break;
@@ -418,7 +423,11 @@ public:
                     case STD_VIDEO_H265_PROFILE_IDC_SCC_EXTENSIONS:
                         break;
                     default:
-                        std::cerr << "\nInvalid h.265 profile: " << profile << std::endl;
+                        // Unknown/invalid H.265 profile from FFmpeg (e.g., profile=0 for
+                        // raw .265 files without container metadata). Default to Main.
+                        std::cerr << "WARNING: Unknown H.265 profile_idc=" << profile
+                                  << " from demuxer, defaulting to MAIN (1)" << std::endl;
+                        return STD_VIDEO_H265_PROFILE_IDC_MAIN;
                 }
             }
             break;
@@ -430,7 +439,9 @@ public:
                     case STD_VIDEO_AV1_PROFILE_PROFESSIONAL:
                         break;
                     default:
-                        std::cerr << "\nInvalid AV1 profile: " << profile << std::endl;
+                        std::cerr << "WARNING: Unknown AV1 profile=" << profile
+                                  << " from demuxer, defaulting to MAIN (0)" << std::endl;
+                        return STD_VIDEO_AV1_PROFILE_MAIN;
                 }
             }
             break;

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -90,6 +90,7 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
     // Assume 4k content for testing surfaces
     const uint32_t surfaceMinWidthExtent  = 4096;
     const uint32_t surfaceMinHeightExtent = 4096;
+    VkVideoCoreProfile videoProfile;
 
     m_codedExtent.width  = pVideoFormat->coded_width;
     m_codedExtent.height = pVideoFormat->coded_height;
@@ -148,15 +149,30 @@ int32_t VkVideoDecoder::StartVideoSequence(VkParserDetectedVideoFormat* pVideoFo
     bool bitstreamHasFilmGrain = (videoCodec == VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR)
                                  && pVideoFormat->filmGrainUsed;
 
-    VkVideoCoreProfile videoProfile = (videoCodec == VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR)
-        ? VkVideoCoreProfile::CreateDecodeAV1Profile(
+    switch (videoCodec)
+    {
+    case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR:
+        videoProfile = VkVideoCoreProfile::CreateDecodeH264Profile(
               pVideoFormat->chromaSubsampling, pVideoFormat->lumaBitDepth,
               pVideoFormat->chromaBitDepth, pVideoFormat->codecProfile,
-              bitstreamHasFilmGrain)
-        : VkVideoCoreProfile::CreateDecodeProfile(
+              pVideoFormat->progressive_sequence ? VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR :
+                                                   VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_KHR);
+        break;
+    case VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR:
+        videoProfile = VkVideoCoreProfile::CreateDecodeAV1Profile(
+              pVideoFormat->chromaSubsampling, pVideoFormat->lumaBitDepth,
+              pVideoFormat->chromaBitDepth, pVideoFormat->codecProfile,
+              bitstreamHasFilmGrain);
+        break;
+
+    default:
+        videoProfile = VkVideoCoreProfile::CreateDecodeProfile(
               videoCodec, pVideoFormat->chromaSubsampling,
               pVideoFormat->lumaBitDepth, pVideoFormat->chromaBitDepth,
               pVideoFormat->codecProfile);
+        break;
+    };
+
     if (!VulkanVideoCapabilities::IsCodecTypeSupported(m_vkDevCtx,
                                                        m_vkDevCtx->GetVideoDecodeQueueFamilyIdx(),
                                                        videoCodec)) {


### PR DESCRIPTION
## Description

In order to validate the support of picture layout supported by the media, the profile info should be built accordingly to the media parsing.

When running the fluster h264 test suite, a lot of regressions have been detected such as AUD_MW_E with latest nvidia driver `595.44.00`

[decode: h.264 ensure PROGRESSIVE is set for progressive-only content](https://github.com/nvpro-samples/vk_video_samples/pull/162/commits/5f10b206d2baf9d4ba26069637f947f22bf8402d)

## Type of change

bug fix

## Issue (optional)

#176 

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.1.0-devel (git-889cf429ee) / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  14
Skipped:         5 (in skip list)
Success Rate: 100.0%

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         58
Crashed:         0
Failed:          0
Not Supported:  14
Skipped:         1 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)


<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
