### PR TITLE
encode: fix critical memory overflow issues in encoder - backport from nvpro

### DIFF
--- a/common/libs/VkCodecUtils/VulkanDeviceMemoryImpl.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceMemoryImpl.cpp
@@ -50,12 +50,18 @@ VkResult VulkanDeviceMemoryImpl::CreateDeviceMemory(const VulkanDeviceContext* v
 {
     deviceMemoryOffset = 0;
 
+    // Align the allocation size to the required alignment.
+    // Vulkan's vkGetImageMemoryRequirements/vkGetBufferMemoryRequirements may return
+    // a size that is not a multiple of alignment, but memory allocations should be aligned.
+    VkDeviceSize alignedSize = (memoryRequirements.size + (memoryRequirements.alignment - 1)) &
+                               ~(memoryRequirements.alignment - 1);
+
     VkMemoryAllocateInfo allocInfo = VkMemoryAllocateInfo();
     allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     allocInfo.memoryTypeIndex = 0;  // Memory type assigned in the next step
 
     // Assign the proper memory type for that buffer
-    allocInfo.allocationSize = memoryRequirements.size;
+    allocInfo.allocationSize = alignedSize;
     MapMemoryTypeToIndex(vkDevCtx, vkDevCtx->getPhysicalDevice(),
                          memoryRequirements.memoryTypeBits,
                          memoryPropertyFlags,

--- a/common/libs/VkCodecUtils/VulkanVideoImagePool.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoImagePool.cpp
@@ -137,9 +137,10 @@ VkResult VulkanVideoImagePool::GetImageSetNewLayout(uint32_t imageIndex,
                                                     VkImageLayout newImageLayout) {
 
     VkResult result = VK_SUCCESS;
-    bool recreateImage = !m_imageResources[imageIndex].RecreateImage();
+    // RecreateImage() returns true if image doesn't exist or needs recreation
+    bool needsCreation = m_imageResources[imageIndex].RecreateImage();
 
-    if (recreateImage) {
+    if (needsCreation) {
         result = m_imageResources[imageIndex].CreateImage(
                            m_vkDevCtx,
                            &m_imageCreateInfo,

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbAV1.h
@@ -181,13 +181,30 @@ public:
     }
 
     bool GetDpbPictureResource(int32_t dpbIdx, VkSharedBaseObj<VulkanVideoImagePoolNode>& dpbImageView) {
+        assert((dpbIdx >= 0) && (dpbIdx < m_maxDpbSize));
+        if ((dpbIdx < 0) || (dpbIdx >= m_maxDpbSize)) {
+            dpbImageView = nullptr;
+            return false;
+        }
         dpbImageView = m_DPB[dpbIdx].dpbImageView;
         return (dpbImageView != nullptr) ? true : false;
     }
-    StdVideoAV1FrameType GetFrameType(int32_t dpbIdx) { assert(dpbIdx != INVALID_IDX); return m_DPB[dpbIdx].frameType; }
-    StdVideoAV1ReferenceName GetRefName(int32_t dpbIdx) { assert(dpbIdx != INVALID_IDX); return m_DPB[dpbIdx].refName; }
-    int32_t GetFrameId(int32_t dpbIdx) { assert(dpbIdx != INVALID_IDX); return m_DPB[dpbIdx].frameId; }
-    int32_t GetPicOrderCntVal(int32_t dpbIdx) { assert(dpbIdx != INVALID_IDX); return m_DPB[dpbIdx].picOrderCntVal; }
+    StdVideoAV1FrameType GetFrameType(int32_t dpbIdx) {
+        assert((dpbIdx >= 0) && (dpbIdx < m_maxDpbSize));
+        return m_DPB[dpbIdx].frameType;
+    }
+    StdVideoAV1ReferenceName GetRefName(int32_t dpbIdx) {
+        assert((dpbIdx >= 0) && (dpbIdx < m_maxDpbSize));
+        return m_DPB[dpbIdx].refName;
+    }
+    int32_t GetFrameId(int32_t dpbIdx) {
+        assert((dpbIdx >= 0) && (dpbIdx < m_maxDpbSize));
+        return m_DPB[dpbIdx].frameId;
+    }
+    int32_t GetPicOrderCntVal(int32_t dpbIdx) {
+        assert((dpbIdx >= 0) && (dpbIdx < m_maxDpbSize));
+        return m_DPB[dpbIdx].picOrderCntVal;
+    }
     int32_t GetNumRefsInGroup(int32_t groupId) {
         assert(groupId < 2);
         return (groupId == 0) ? m_numRefFramesInGroup1 : m_numRefFramesInGroup2;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
@@ -182,8 +182,8 @@ int8_t VkEncDpbH264::DpbPictureStart(const PicInfoH264 *pPicInfo,
     // - the second field in decoding order is not an IDR picture and
     // - does not include a memory_management_control_operation syntax element equal to 5.
 
-    // TODO: what if there is no current picture?
-    if (((m_DPB[m_currDpbIdx].state == DPB_TOP) || (m_DPB[m_currDpbIdx].state == DPB_BOTTOM)) &&  // contains a single field
+    if ((m_currDpbIdx >= 0) && (m_currDpbIdx < MAX_DPB_SLOTS) &&
+        ((m_DPB[m_currDpbIdx].state == DPB_TOP) || (m_DPB[m_currDpbIdx].state == DPB_BOTTOM)) &&  // contains a single field
             pPicInfo->field_pic_flag &&                                                      // current is a field
             (((m_DPB[m_currDpbIdx].state == DPB_TOP) && pPicInfo->bottom_field_flag) ||
              ((m_DPB[m_currDpbIdx].state == DPB_BOTTOM) && !pPicInfo->bottom_field_flag)) &&  // opposite parity

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
@@ -542,7 +542,10 @@ void VkEncDpbH264::DpbBumping(bool alwaysbump)
                 minFoc = i;
             }
         }
-        m_DPB[minFoc].state = DPB_EMPTY;
+        // Only access m_DPB if we found a valid entry
+        if ((minFoc >= 0) && (minFoc < MAX_DPB_SLOTS)) {
+            m_DPB[minFoc].state = DPB_EMPTY;
+        }
     }
 }
 
@@ -1644,7 +1647,10 @@ uint64_t VkEncDpbH264::GetPictureTimestamp(int32_t dpb_idx)
 
 void VkEncDpbH264::SetCurRefFrameTimeStamp(uint64_t refFrameTimeStamp)
 {
-    m_DPB[m_currDpbIdx].refFrameTimeStamp = refFrameTimeStamp;
+    assert((m_currDpbIdx >= 0) && (m_currDpbIdx <= MAX_DPB_SLOTS));
+    if ((m_currDpbIdx >= 0) && (m_currDpbIdx <= MAX_DPB_SLOTS)) {
+        m_DPB[m_currDpbIdx].refFrameTimeStamp = refFrameTimeStamp;
+    }
 }
 
 uint32_t VkEncDpbH264::GetDirtyIntraRefreshRegions(int32_t dpb_idx)
@@ -1657,7 +1663,10 @@ uint32_t VkEncDpbH264::GetDirtyIntraRefreshRegions(int32_t dpb_idx)
 
 void VkEncDpbH264::SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions)
 {
-    m_DPB[m_currDpbIdx].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+    assert((m_currDpbIdx >= 0) && (m_currDpbIdx <= MAX_DPB_SLOTS));
+    if ((m_currDpbIdx >= 0) && (m_currDpbIdx <= MAX_DPB_SLOTS)) {
+        m_DPB[m_currDpbIdx].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+    }
 }
 
 // Returns a "view" of the DPB in terms of the entries holding valid reference

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH265.cpp
@@ -937,5 +937,8 @@ uint32_t VkEncDpbH265::GetDirtyIntraRefreshRegions(uint32_t dpb_idx)
 
 void VkEncDpbH265::SetCurDirtyIntraRefreshRegions(uint32_t dirtyIntraRefreshRegions)
 {
-    m_stDpb[m_curDpbIndex].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+    assert((m_curDpbIndex >= 0) && (m_curDpbIndex < m_dpbSize));
+    if ((m_curDpbIndex >= 0) && (m_curDpbIndex < m_dpbSize)) {
+        m_stDpb[m_curDpbIndex].dirtyIntraRefreshRegions = dirtyIntraRefreshRegions;
+    }
 }


### PR DESCRIPTION
## Description

Backport multiple patches from https://github.com/nvpro-samples/vk_video_samples/pull/188

 - [common: VulkanVideoImagePool fix inverted image creation logic](https://github.com/nvpro-samples/vk_video_samples/pull/188/changes/acfa853633504486372ac48055d1e7e010a61338)


 - [encoder H.264: fix memory corruption issue](https://github.com/nvpro-samples/vk_video_samples/pull/188/changes/700f0b538297bea14fde4bd6d2f97d75dfb07a77)



 - [encode: add bounds checking to DPB management across all codecs](https://github.com/nvpro-samples/vk_video_samples/pull/188/changes/87073cadd22562e3d032327f6fbe33adb5b736b5)


 - [vulkan: fix memory allocation size alignment in CreateDeviceMemory](https://github.com/nvpro-samples/vk_video_samples/pull/188/changes/981834c4b8f5591f535be6d08c46edc00d91baa8)


## Type of change

bug fixes - backport

## Issue (optional)

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  14
Skipped:         2 (in skip list)
Success Rate: 100.0%

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-c36e3ce934) / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  14
Skipped:         5 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
