### PR TITLE
encode: fixes related to pNext-chaining

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1930,13 +1930,10 @@ VkResult VkVideoEncoder::RecordVideoCodingCmd(VkSharedBaseObj<VkVideoEncodeFrame
         videoInlineQueryInfoKHR.queryPool = queryPool;
         videoInlineQueryInfoKHR.firstQuery = querySlotId;
         videoInlineQueryInfoKHR.queryCount = numQuerySamples;
-        VkBaseInStructure* pStruct = (VkBaseInStructure*)&encodeFrameInfo->encodeInfo;
-        vk::ChainNextVkStruct(*pStruct, videoInlineQueryInfoKHR);
+
+        vk::ChainNextVkStruct(encodeFrameInfo->encodeInfo, videoInlineQueryInfoKHR);
 
         vkDevCtx->CmdEncodeVideoKHR(cmdBuf, &encodeFrameInfo->encodeInfo);
-
-        // Remove the stack pointer from the chain, causes a use after free otherwise in GetEncodeFrameInfoH264
-        encodeFrameInfo->encodeInfo.pNext = videoInlineQueryInfoKHR.pNext;
     }
     else
     {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1916,9 +1916,10 @@ VkResult VkVideoEncoder::RecordVideoCodingCmd(VkSharedBaseObj<VkVideoEncodeFrame
                                                           encodeFrameInfo->controlCmd};
         vkDevCtx->CmdControlVideoCodingKHR(cmdBuf, &renderControlInfo);
 
+        assert(encodeFrameInfo->pControlCmdChain);
+
         m_beginRateControlInfo = *(VkVideoEncodeRateControlInfoKHR*)encodeFrameInfo->pControlCmdChain;
-        // Do not walk the chain, otherwise we end up creating a loop here.
-        m_beginRateControlInfo.pNext = NULL;
+        const_cast<VkBaseInStructure*>(static_cast<const VkBaseInStructure*>(m_beginRateControlInfo.pNext))->pNext = NULL;
     }
 
     if (m_videoMaintenance1FeaturesSupported)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -56,10 +56,7 @@ public:
 
     struct VkVideoEncodeFrameInfo : public VkVideoRefCountBase
     {
-        VkStructureType GetType() {
-            return (encodeInfo.pNext == nullptr) ?
-                    VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR : reinterpret_cast<const VkBaseInStructure*>(encodeInfo.pNext)->sType;
-        }
+        virtual VkVideoCodecOperationFlagBitsKHR GetCodecType() const = 0;
 
         VkVideoEncodeFrameInfo(const void* pNext = nullptr)
             : encodeInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR, pNext}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -250,7 +250,8 @@ public:
         virtual void Reset(bool releaseResources = true) {
             // Clear and check state
             assert(encodeInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR);
-            assert(encodeInfo.pNext != nullptr);
+
+            encodeInfo.pNext = nullptr;
 
             if ((frameInputOrderNum == (uint64_t)-1) &&
                 (frameEncodeInputOrderNum == (uint64_t)-1) &&

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
@@ -73,7 +73,7 @@ public:
             pictureInfo.pStdPictureInfo = &stdPictureInfo;
         }
 
-        virtual void Reset(bool releaseResources = true) {
+        virtual void Reset(bool releaseResources = true) override {
 
             pictureInfo.pNext = nullptr;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
@@ -48,6 +48,10 @@ public:
         VkVideoEncodeAV1RateControlInfoKHR rateControlInfoAV1;
         VkVideoEncodeAV1RateControlLayerInfoKHR rateControlLayersInfoAV1[1];
 
+        VkVideoCodecOperationFlagBitsKHR GetCodecType() const override {
+            return VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR;
+        }
+
         VkVideoEncodeFrameInfoAV1()
             : VkVideoEncodeFrameInfo(&pictureInfo)
             , pictureInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR }
@@ -184,7 +188,7 @@ protected:
 
 private:
     VkVideoEncodeFrameInfoAV1* GetEncodeFrameInfoAV1(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo) {
-        assert(VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR == encodeFrameInfo->GetType());
+        assert(VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR == encodeFrameInfo->GetCodecType());
         VkVideoEncodeFrameInfo* pEncodeFrameInfo = encodeFrameInfo;
         return (VkVideoEncodeFrameInfoAV1*)pEncodeFrameInfo;
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
@@ -79,6 +79,10 @@ public:
 
             // Reset the base first
             VkVideoEncodeFrameInfo::Reset(releaseResources);
+
+            // After resetting the base structure parameters, start building the pNext chain again
+            assert(pictureInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR);
+            encodeInfo.pNext = &pictureInfo;
         }
 
         virtual ~VkVideoEncodeFrameInfoAV1() {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
@@ -92,6 +92,9 @@ private:
             // Reset the base first
             VkVideoEncodeFrameInfo::Reset(releaseResources);
 
+            // After resetting the base structure parameters, start building the pNext chain again
+            encodeInfo.pNext = &pictureInfo;
+
             // Clear and check state
             assert(pictureInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR);
             assert(naluSliceInfo[0].sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
@@ -48,6 +48,10 @@ private:
         StdVideoEncodeH264RefListModEntry        refList1ModOperations[MAX_REFFERENCES];
         StdVideoEncodeH264RefPicMarkingEntry     refPicMarkingEntry[MAX_MEM_MGMNT_CTRL_OPS_COMMANDS];
 
+        VkVideoCodecOperationFlagBitsKHR GetCodecType() const override {
+            return VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR;
+        }
+
         VkVideoEncodeFrameInfoH264()
           : VkVideoEncodeFrameInfo(&pictureInfo)
           , pictureInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR }
@@ -153,7 +157,7 @@ protected:
 private:
 
     VkVideoEncodeFrameInfoH264* GetEncodeFrameInfoH264(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo) {
-        assert(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR == encodeFrameInfo->GetType());
+        assert(VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR == encodeFrameInfo->GetCodecType());
         VkVideoEncodeFrameInfo* pEncodeFrameInfo = encodeFrameInfo;
         return (VkVideoEncodeFrameInfoH264*)pEncodeFrameInfo;
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
@@ -85,7 +85,7 @@ private:
             stdDpbSlotInfo->pStdReferenceInfo = stdReferenceInfo;
         };
 
-        virtual void Reset(bool releaseResources = true) {
+        virtual void Reset(bool releaseResources = true) override {
 
             pictureInfo.pNext = nullptr;
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
@@ -46,6 +46,10 @@ private:
         StdVideoEncodeH265ReferenceInfo          stdReferenceInfo[MAX_REFFERENCES];
         VkVideoEncodeH265DpbSlotInfoKHR          stdDpbSlotInfo[MAX_REFFERENCES];
 
+        VkVideoCodecOperationFlagBitsKHR GetCodecType() const override {
+            return VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR;
+        }
+
         VkVideoEncodeFrameInfoH265()
           : VkVideoEncodeFrameInfo(&pictureInfo)
           , pictureInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR }
@@ -148,7 +152,7 @@ protected:
 private:
 
     VkVideoEncodeFrameInfoH265* GetEncodeFrameInfoH265(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo) {
-        assert(VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR == encodeFrameInfo->GetType());
+        assert(VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR == encodeFrameInfo->GetCodecType());
         VkVideoEncodeFrameInfo* pEncodeFrameInfo = encodeFrameInfo;
         return (VkVideoEncodeFrameInfoH265*)pEncodeFrameInfo;
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
@@ -91,6 +91,9 @@ private:
             // Reset the base first
             VkVideoEncodeFrameInfo::Reset(releaseResources);
 
+            // After resetting the base structure parameters, start building the pNext chain again
+            encodeInfo.pNext = &pictureInfo;
+
             // Clear and check state
             assert(pictureInfo.sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR);
             assert(naluSliceSegmentInfo[0].sType == VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR);

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
@@ -84,7 +84,7 @@ private:
             stdDpbSlotInfo->pStdReferenceInfo = stdReferenceInfo;
         };
 
-        virtual void Reset(bool releaseResources = true) {
+        virtual void Reset(bool releaseResources = true) override {
 
             pictureInfo.pNext = nullptr;
 


### PR DESCRIPTION
## Description

This change fixes a regression arising from https://github.com/KhronosGroup/Vulkan-Video-Samples/commit/62c184cc00879137217c01c1575c9c280e147df4 which prevented the quantization maps functionality from working correctly and also regressed RC struct chaining code.

## Type of change

Bug fix (and associated minor cleanup)

## Issue (optional)

See https://github.com/KhronosGroup/Vulkan-Video-Samples/pull/53#issuecomment-4177777784

## Tests

### NVIDIA L2 / NVIDIA 595.44.05 / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         62
Crashed:         0
Failed:          0
Not Supported:   9
Skipped:         2 (in skip list)
Success Rate: 100.0%