### PR TITLE
ci: bump GitHub Actions and Node.js versions

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install commitlint
         run: npm install --save-dev @commitlint/cli

--- a/.github/workflows/cts-build.yml
+++ b/.github/workflows/cts-build.yml
@@ -69,9 +69,9 @@ jobs:
           path: vulkan-video-samples
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install lxml
         run: pip install lxml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set i386 environment variables
         if: matrix.platform == 'linux-x86'
@@ -193,7 +193,7 @@ jobs:
           zip -r ../${{ env.REPO_NAME }}-release-${{ matrix.platform }}.zip ${{ env.REPO_NAME }}-release/
           popd
       - name: Upload linux release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.REPO_NAME }}-release-${{ matrix.platform }}
           path: ${{ env.REPO_NAME }}-release-${{ matrix.platform }}.zip
@@ -232,16 +232,16 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
           choco install --yes zip
 
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install FFmpeg
         if: matrix.platform == 'windows-x64-ffmpeg'
@@ -302,7 +302,7 @@ jobs:
             zip -r ../${{ env.REPO_NAME }}-release-${{ matrix.platform }}.zip ${{ env.REPO_NAME }}-release
             popd
       - name: Upload windows release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.REPO_NAME }}-release-${{ matrix.platform }}
           path: ${{ env.REPO_NAME }}-release-${{ matrix.platform }}.zip

--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Write PR body to file
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         platform: [linux-x86_64, linux-x86_64-ffmpeg, linux-x86, windows-x64, windows-x64-ffmpeg, win-arm64]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.REPO_NAME }}-release-${{ matrix.platform }}
           path: ./
@@ -31,7 +31,7 @@ jobs:
         run: |
           mv ${{ env.REPO_NAME }}-release-${{ matrix.platform }}.zip ${{ env.REPO_NAME }}-${{ github.ref_name }}-${{ matrix.platform }}.zip
       - name: Upload renamed artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.REPO_NAME }}-${{ github.ref_name }}-${{ matrix.platform }}
           path: ${{ env.REPO_NAME }}-${{ github.ref_name }}-${{ matrix.platform }}.zip
@@ -44,7 +44,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -67,7 +67,7 @@ jobs:
         platform: [linux-x86_64, linux-x86_64-ffmpeg, linux-x86, windows-x64, windows-x64-ffmpeg, win-arm64]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.REPO_NAME }}-${{ github.ref_name }}-${{ matrix.platform }}
           path: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -67,7 +67,7 @@ jobs:
           cmake --build BUILD --parallel $BUILD_JOBS --config Release
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Description

All the CI jobs have the following warning:

```Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3, actions/setup-python@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/```

**IMPORTANT:**
- Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
- Node.js 20 will be removed on September 16th, 2026.

The action versions were bumped to match Node.js 24:
- actions/checkout: v2/v3/v4 -> v6
- actions/setup-python: v4/v5 -> v6
- actions/setup-node: v4 -> v6
- actions/upload-artifact: v4 -> v7
- actions/download-artifact: v4 -> v8

Python pinned to 3.12 in every workflow that uses it.

Currently, there is no new version for `msvc-dev-cmd`, therefore, 3 warnings remain. Support for Node 24 is added in a merge request but not yet merged.

## Type of change

feature

## Tests

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.0-devel (git-055aec542e) / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         63
Crashed:         0
Failed:          0
Not Supported:   6
Skipped:         4 (in skip list)
Success Rate: 100.0%

