### PR TITLE
parser: cleanup error handling in vp9 parser

### DIFF
--- a/common/libs/VkCodecUtils/VulkanFrame.cpp
+++ b/common/libs/VkCodecUtils/VulkanFrame.cpp
@@ -361,7 +361,6 @@ bool VulkanFrame<FrameDataType>::OnFrame( int32_t renderIndex,
 
         VkVideoQueueResult result = m_videoQueue->GetNextFrame(pLastDecodedFrame);
         if (result == VkVideoQueueResult::Error) {
-            std::cerr << "Error: decoder reported a fatal error during frame retrieval" << std::endl;
             continueLoop = false;
         } else if (result == VkVideoQueueResult::EndOfStream) {
             continueLoop = false;

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
@@ -465,6 +465,14 @@ VkVideoQueueResult VulkanVideoProcessor::GetNextFrame(VulkanDecodedFrame* pFrame
 
     if (parserError) {
         m_videoStreamsCompleted = true;
+        VkResult lastResult = GetDecoderLastResult();
+        if (IsVideoUnsupportedResult(lastResult)) {
+            fprintf(stderr, "ERROR: decoder reported unsupported video configuration (VkResult %d)\n", lastResult);
+        } else if (lastResult == VK_SUCCESS) {
+            fprintf(stderr, "ERROR: parser reported a fatal error (no VkResult set by decoder)\n");
+        } else {
+            fprintf(stderr, "ERROR: decoder reported a fatal error (VkResult %d)\n", lastResult);
+        }
         return VkVideoQueueResult::Error;
     }
 

--- a/tests/decode_samples.json
+++ b/tests/decode_samples.json
@@ -487,6 +487,15 @@
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/vp9/vp9-1280x720-svc.ivf",
       "source_checksum": "8a8dc19ce33eaeb48a1b800fb775a45b358cf8a779ea97face108e2e6ea958f2",
       "source_filepath": "video/vp9/vp9-1280x720-svc.ivf"
+    },
+    {
+      "name": "vp90-2-02-size-64x34",
+      "codec": "vp9",
+      "description": "low resolution",
+      "expected_output_md5": "a9252d8d594f13602b49469fec1e7560",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/vp9/vp90-2-02-size-64x34.webm",
+      "source_checksum": "cf6cef4b67865f515d6f59986e6e4822a4da8060bac92b54009c5f6f17b1c641",
+      "source_filepath": "video/vp9/vp90-2-02-size-64x34.webm"
     }
   ]
 }

--- a/vk_video_decoder/libs/NvVideoParser/src/VulkanVP9Decoder.cpp
+++ b/vk_video_decoder/libs/NvVideoParser/src/VulkanVP9Decoder.cpp
@@ -187,7 +187,9 @@ bool VulkanVP9Decoder::ParseByteStream(const VkParserBitstreamPacket* pck, size_
 
                 }
 
-                ParseFrameHeader(frame_size);
+                if (!ParseFrameHeader(frame_size)) {
+                    return false;
+                }
 
                 if (frames_in_superframe > 0) {
                     sizeparsed += frame_sizes[framesdone];
@@ -231,8 +233,8 @@ bool VulkanVP9Decoder::ParseFrameHeader(uint32_t framesize)
     //parse uncompressed header
     if(!ParseUncompressedHeader())
     {
-        assert((!"Error in ParseUncompressedVP9\n"));
-        return 0;
+        nvParserLog("Error in ParseUncompressedVP9\n");
+        return false;
     }
     if (m_PicData.show_existing_frame == true)  {
         // display an existing frame
@@ -243,7 +245,7 @@ bool VulkanVP9Decoder::ParseFrameHeader(uint32_t framesize)
 
         AddBuffertoOutputQueue(pDispPic);
 
-        return 0;
+        return true;
     }
 
     // handle bitstream start offset alignment (for super frame)
@@ -261,7 +263,7 @@ bool VulkanVP9Decoder::ParseFrameHeader(uint32_t framesize)
     m_pVkPictureData->bitstreamDataOffset = (size_t)(m_nalu.start_offset & ~((int64_t)m_bufferOffsetAlignment - 1));
 
     if (!BeginPicture(m_pVkPictureData)) {
-        assert(!"BeginPicture failed");
+        nvParserLog("BeginPicture failed\n");
         return false;
     }
 
@@ -291,7 +293,7 @@ bool VulkanVP9Decoder::ParseFrameHeader(uint32_t framesize)
         m_pCurrPic = nullptr;
     }
 
-    return 1;
+    return true;
 }
 
 void VulkanVP9Decoder::UpdateFramePointers(VkPicIf* currentPicture)
@@ -387,7 +389,7 @@ bool VulkanVP9Decoder::ParseUncompressedHeader()
     pStdPicInfo->profile = (StdVideoVP9Profile)profile;
     if (pStdPicInfo->profile == STD_VIDEO_VP9_PROFILE_3) {
         if (u(1) != 0) {
-            assert(!"Invalid syntax");
+            nvParserLog("Invalid syntax\n");
             return false;
         }
     }
@@ -878,7 +880,7 @@ bool VulkanVP9Decoder::BeginPicture(VkParserPictureData* pnvpd)
     }
 
     if (!init_sequence(&nvsi)) {
-        assert(!"init_sequence failed!");
+        nvParserLog("init_sequence failed!\n");
         return false;
     }
 


### PR DESCRIPTION
## Description

This PR enhances the detection of error in VP9 parser to at least reports an unsupported media in case of dimension bounds reached.

It removes useless assert as well using the nvParser logger instead

## Type of change

bug fix

## Issue (optional)



## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-e6064cf077) / Ubuntu 24.04.4 LTS

Total Tests:    74
Passed:         52
Crashed:         0
Failed:          0
Not Supported:  13
Skipped:         9 (in skip list)

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    74
Passed:         58
Crashed:         0
Failed:          0
Not Supported:  15
Skipped:         1 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
