### PR TITLE
tests: clean up the results and provide csv output similar to fluster

### DIFF
--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -283,7 +283,7 @@
       "width": 7680,
       "height": 4320,
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/7680x4320_420_8le.yuv",
-      "source_checksum": "0a7799afe89ad34aeb62b293c4c310a9a15c34961e9203a8499027ad775929b0",
+      "source_checksum": "8d12097d0ad9d8eb89a626b394df6c84213efe3f6c29823d345a564a1e8ec762",
       "source_filepath": "video/yuv/7680x4320_420_8le.yuv"
     },
     {
@@ -308,7 +308,7 @@
       "width": 7680,
       "height": 4320,
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/7680x4320_420_8le.yuv",
-      "source_checksum": "0a7799afe89ad34aeb62b293c4c310a9a15c34961e9203a8499027ad775929b0",
+      "source_checksum": "8d12097d0ad9d8eb89a626b394df6c84213efe3f6c29823d345a564a1e8ec762",
       "source_filepath": "video/yuv/7680x4320_420_8le.yuv"
     },
     {
@@ -333,7 +333,7 @@
       "width": 7680,
       "height": 4320,
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/7680x4320_420_8le.yuv",
-      "source_checksum": "0a7799afe89ad34aeb62b293c4c310a9a15c34961e9203a8499027ad775929b0",
+      "source_checksum": "8d12097d0ad9d8eb89a626b394df6c84213efe3f6c29823d345a564a1e8ec762",
       "source_filepath": "video/yuv/7680x4320_420_8le.yuv"
     },
     {

--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -408,7 +408,7 @@ class VulkanVideoTestFrameworkBase:
             return self.results_dir
         return None
 
-    def _result_to_dict(self, result: TestResult, test_type: str) -> dict:
+    def result_to_dict(self, result: TestResult, test_type: str) -> dict:
         """Convert a TestResult to a dictionary for JSON export."""
         test_name = (result.config.display_name
                      if hasattr(result.config, 'display_name')
@@ -438,10 +438,6 @@ class VulkanVideoTestFrameworkBase:
             result_dict["profile"] = result.config.profile
 
         return result_dict
-
-    def result_to_dict(self, result: TestResult, test_type: str) -> dict:
-        """Public wrapper for converting a TestResult to dictionary form."""
-        return self._result_to_dict(result, test_type)
 
     def export_results_json(self, output_file: str, test_type: str) -> bool:
         """Export test results to JSON file. Returns True on success."""

--- a/tests/libs/video_test_result_reporter.py
+++ b/tests/libs/video_test_result_reporter.py
@@ -31,14 +31,30 @@ def get_status_display(status: VideoTestStatus) -> tuple:
         Tuple of (status_text, status_symbol)
     """
     if status == VideoTestStatus.SUCCESS:
-        return "PASS", "✓"
+        return "PASS", "✔️"
     if status == VideoTestStatus.NOT_SUPPORTED:
         return "N/S", "○"
     if status == VideoTestStatus.CRASH:
         return "CRASH", "💥"
     if status == VideoTestStatus.SKIPPED:
         return "SKIP", "⊘"
-    return "FAIL", "✗"
+    return "FAIL", "❌"
+
+
+def get_status_symbol_from_str(status) -> str:
+    """Return the symbol for a status, accepting either a status string
+    (e.g. "success") or a VideoTestStatus enum value.
+    """
+    if isinstance(status, VideoTestStatus):
+        status = status.value
+    symbols = {
+        VideoTestStatus.SUCCESS.value: "✔️",
+        VideoTestStatus.NOT_SUPPORTED.value: "○",
+        VideoTestStatus.CRASH.value: "💥",
+        VideoTestStatus.SKIPPED.value: "⊘",
+        VideoTestStatus.ERROR.value: "❌",
+    }
+    return symbols.get(status, status)
 
 
 def print_codec_breakdown(codec_results: dict) -> None:
@@ -77,39 +93,40 @@ def print_detailed_results(results: List[TestResult]) -> None:
         )
 
 
-def print_final_summary(counts: tuple, test_type: str) -> bool:
+def print_final_summary(counts: tuple, test_type: str = "") -> bool:
     """Print final summary and return success status
 
     Args:
         counts: Tuple of (passed, not_supported, crashed, failed)
-        test_type: Type of test (e.g., "decoder", "encoder")
+        test_type: Type of test (e.g., "decoder", "encoder"). When empty,
+                   the type label is omitted from the messages.
 
     Returns:
         True if all tests passed (or only not supported), False otherwise
     """
     passed, not_supported, crashed, failed = counts
     total_errors = failed + crashed
-    test_type_upper = test_type.upper()
+    label = f"{test_type.upper()} " if test_type else ""
 
     if total_errors == 0:
         if not_supported > 0:
             print(
-                f"\n✓ ALL TESTS COMPLETED - {passed} passed, "
+                f"\n✔️ ALL TESTS COMPLETED - {passed} passed, "
                 f"{not_supported} not supported by hardware/driver"
             )
         else:
-            print(f"\n🎉 ALL {test_type_upper} TESTS PASSED!")
+            print(f"\n🎉 ALL {label}TESTS PASSED!")
         return True
 
     if crashed > 0 and failed > 0:
         print(
-            f"\n💥 {crashed} {test_type_upper} TEST(S) CRASHED, "
+            f"\n💥 {crashed} {label}TEST(S) CRASHED, "
             f"{failed} FAILED!"
         )
     elif crashed > 0:
-        print(f"\n💥 {crashed} {test_type_upper} TEST(S) CRASHED!")
+        print(f"\n💥 {crashed} {label}TEST(S) CRASHED!")
     else:
-        print(f"\n✗ {failed} {test_type_upper} TEST(S) FAILED!")
+        print(f"\n❌ {failed} {label}TEST(S) FAILED!")
     return False
 
 

--- a/tests/vvs_test_runner.py
+++ b/tests/vvs_test_runner.py
@@ -27,6 +27,7 @@ if __package__ is None or __package__ == "":
     sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 
 import json
+import csv
 from pathlib import Path
 from typing import List, Tuple, Optional
 from enum import Enum
@@ -57,6 +58,11 @@ from tests.libs.video_test_framework_encode import (
 from tests.libs.video_test_framework_decode import (
     VulkanVideoDecodeTestFramework,
     DecodeTestSample,
+)
+
+from tests.libs.video_test_result_reporter import (
+    get_status_symbol_from_str,
+    print_final_summary,
 )
 
 
@@ -358,34 +364,21 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
                     total_enabled += 1
         return total_enabled
 
-    def _print_final_status(self, overall_success: bool,
-                            test_counts: dict) -> None:
-        """Print final status message
+    def _print_final_status(self, test_counts: dict) -> None:
+        """Print final status message via the shared print_final_summary.
 
         Args:
-            overall_success: Whether all tests passed
             test_counts: Dict with keys 'passed', 'not_supported',
-                        'crashed', 'failed'
+                         'crashed', 'failed'
         """
-        passed = test_counts['passed']
-        not_supported = test_counts['not_supported']
-        crashed = test_counts['crashed']
-        failed = test_counts['failed']
-
-        if overall_success:
-            if not_supported > 0:
-                print(f"\n✓ ALL TESTS COMPLETED - {passed} passed, "
-                      f"{not_supported} not supported by "
-                      f"hardware/driver")
-            else:
-                print("\n🎉 ALL TESTS PASSED!")
-        elif crashed > 0 and failed > 0:
-            print(f"\n💥 {crashed} TEST(S) CRASHED, "
-                  f"{failed} FAILED!")
-        elif crashed > 0:
-            print(f"\n💥 {crashed} TEST(S) CRASHED!")
-        else:
-            print(f"\n✗ {failed} TEST(S) FAILED!")
+        print_final_summary(
+            (
+                test_counts['passed'],
+                test_counts['not_supported'],
+                test_counts['crashed'],
+                test_counts['failed'],
+            ),
+        )
 
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     def print_summary(self, encode_results: Optional[List] = None,
@@ -455,7 +448,6 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
 
         overall_success = encode_success and decode_success
         self._print_final_status(
-            overall_success,
             {
                 'passed': total_passed,
                 'not_supported': total_not_supported,
@@ -474,7 +466,7 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
             # Combine results from both frameworks using base class helper
             if self.encode_framework:
                 for result in self.encode_framework.results:
-                    result_dict = self.encode_framework._result_to_dict(
+                    result_dict = self.encode_framework.result_to_dict(
                         result,
                         "encoder",
                     )
@@ -482,7 +474,7 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
 
             if self.decode_framework:
                 for result in self.decode_framework.results:
-                    result_dict = self.decode_framework._result_to_dict(
+                    result_dict = self.decode_framework.result_to_dict(
                         result,
                         "decoder",
                     )
@@ -513,6 +505,42 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
                     "results": combined_results
                 }, f, indent=2)
 
+            print(f"✓ Results exported to {output_file}")
+            return True
+
+        except (OSError, IOError) as e:
+            print(f"✗ Failed to export results: {e}")
+            return False
+
+    def export_results_csv(self, output_file: str) -> bool:
+        """Export test results to CSV file"""
+        try:
+            combined_results = []
+            # Combine results from both frameworks using base class helper
+            if self.encode_framework:
+                for result in self.encode_framework.results:
+                    result_dict = self.encode_framework.result_to_dict(
+                        result,
+                        "encoder",
+                    )
+                    combined_results.append(result_dict)
+
+            if self.decode_framework:
+                for result in self.decode_framework.results:
+                    result_dict = self.decode_framework.result_to_dict(
+                        result,
+                        "decoder",
+                    )
+                    combined_results.append(result_dict)
+            Path(output_file).parent.mkdir(parents=True, exist_ok=True)
+            with open(output_file, mode="w", encoding="utf8",
+                      newline="") as file:
+                writer = csv.writer(file, delimiter="|")
+                for r in combined_results:
+                    res_row = []
+                    res_row.append(r["name"])
+                    res_row.append(get_status_symbol_from_str(r["status"]))
+                    writer.writerow(res_row)
             print(f"✓ Results exported to {output_file}")
             return True
 
@@ -626,6 +654,9 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--export-json", "-j",
         help="Export results to JSON file")
+    parser.add_argument(
+        "--export-csv",
+        help="Export results to CSV file")
     parser.add_argument(
         "--codec", "-c",
         choices=["h264", "h265", "av1", "vp9"],
@@ -840,6 +871,11 @@ def run_framework_tests(args: argparse.Namespace, encoder_path: str,
         if not json_path.is_absolute():
             json_path = Path.cwd() / json_path
         framework.export_results_json(str(json_path))
+    if args.export_csv:
+        csv_path = Path(args.export_csv)
+        if not csv_path.is_absolute():
+            csv_path = Path.cwd() / csv_path
+        framework.export_results_csv(str(csv_path))
 
     return success
 


### PR DESCRIPTION
## Description

The report is now unified and similar to fluster result symbols. It is possible to convert json to csv

## Type of change

cleanup


## Issue (optional)


## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.0.6 (git-0e095aab43) / Ubuntu 24.04.4 LTS

Total Tests:    73
Passed:         63
Crashed:         0
Failed:          0
Not Supported:   6
Skipped:         4 (in skip list)
Success Rate: 100.0%


## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
