### PR TITLE
tests: add vp9 skip test

### DIFF
--- a/tests/decode_samples.json
+++ b/tests/decode_samples.json
@@ -496,6 +496,15 @@
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/vp9/vp90-2-02-size-64x34.webm",
       "source_checksum": "cf6cef4b67865f515d6f59986e6e4822a4da8060bac92b54009c5f6f17b1c641",
       "source_filepath": "video/vp9/vp90-2-02-size-64x34.webm"
+    },
+    {
+      "name": "vp9_skip",
+      "codec": "vp9",
+      "description": "skip test for vp9",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/vp9/vp9-skip.ivf",
+      "source_checksum": "d9a6f09bbb92bd59b585cac2aff12476d4e1674f303dc13a1d95f6b5cf1faebe",
+      "source_filepath": "video/vp9/vp9-skip.ivf",
+      "expected_output_md5": "c2d6e7e425d883f2c2cce7c80711c566"
     }
   ]
 }


### PR DESCRIPTION
## Description

Add a new test

## Type of change

tests

## Issue (optional)



## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-e6064cf077) / Ubuntu 24.04.4 LTS

Total Tests:    75
Passed:         53
Crashed:         0
Failed:          0
Not Supported:  13
Skipped:         9 (in skip list)
Success Rate: 100.0%


### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    75
Passed:         59
Crashed:         0
Failed:          0
Not Supported:  15
Skipped:         1 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
