### PR TITLE
build: fix g++ 16 support and no vulkan system package support

### DIFF
--- a/cmake/FindVulkanSDK.cmake
+++ b/cmake/FindVulkanSDK.cmake
@@ -22,6 +22,7 @@ MACRO(FIND_VULKAN_HEADERS VK_MINIMUM_MAJOR_VERSION VK_MINIMUM_MINOR_VERSION VK_M
                 set(VULKAN_HEADERS_INCLUDE_DIR ${VULKAN_PC_INCLUDEDIR})
                 set(VULKAN_LIBRARIES ${VULKAN_PC_LIBRARIES})
                 message(STATUS "VULKAN_HEADERS_INCLUDE_DIR: ${VULKAN_HEADERS_INCLUDE_DIR}")
+                link_directories(${VULKAN_PC_LIBRARY_DIRS})
                 set(USE_SYSTEM_VULKAN ON)
             endif()
         endif()

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -58,8 +58,8 @@ public:
     {
         virtual VkVideoCodecOperationFlagBitsKHR GetCodecType() const = 0;
 
-        VkVideoEncodeFrameInfo(const void* pNext = nullptr)
-            : encodeInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR, pNext}
+        VkVideoEncodeFrameInfo()
+            : encodeInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR, nullptr }
             , quantizationMapInfo()
             , intraRefreshInfo()
             , frameInputOrderNum(uint64_t(-1))

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
@@ -53,7 +53,7 @@ public:
         }
 
         VkVideoEncodeFrameInfoAV1()
-            : VkVideoEncodeFrameInfo(&pictureInfo)
+            : VkVideoEncodeFrameInfo()
             , pictureInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR }
             , stdPictureInfo{}
             , stdTileInfo{}
@@ -70,6 +70,8 @@ public:
             , rateControlInfoAV1{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_INFO_KHR }
             , rateControlLayersInfoAV1{{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_LAYER_INFO_KHR }}
         {
+            encodeInfo.pNext = &pictureInfo;
+
             pictureInfo.pStdPictureInfo = &stdPictureInfo;
         }
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH264.h
@@ -53,7 +53,7 @@ private:
         }
 
         VkVideoEncodeFrameInfoH264()
-          : VkVideoEncodeFrameInfo(&pictureInfo)
+          : VkVideoEncodeFrameInfo()
           , pictureInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR }
           , naluSliceInfo{}
           , stdPictureInfo()
@@ -67,6 +67,8 @@ private:
           , refList1ModOperations{}
           , refPicMarkingEntry{}
         {
+            encodeInfo.pNext = &pictureInfo;
+
             pictureInfo.naluSliceEntryCount = 1; // FIXME: support more than one
             pictureInfo.pNaluSliceEntries = naluSliceInfo;
             pictureInfo.pStdPictureInfo = &stdPictureInfo;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderH265.h
@@ -51,7 +51,7 @@ private:
         }
 
         VkVideoEncodeFrameInfoH265()
-          : VkVideoEncodeFrameInfo(&pictureInfo)
+          : VkVideoEncodeFrameInfo()
           , pictureInfo { VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR }
           , naluSliceSegmentInfo{}
           , stdPictureInfo()
@@ -64,6 +64,8 @@ private:
           , stdReferenceInfo{}
           , stdDpbSlotInfo{}
         {
+            encodeInfo.pNext = &pictureInfo;
+
             pictureInfo.naluSliceSegmentEntryCount = 1;
             pictureInfo.pNaluSliceSegmentEntries = naluSliceSegmentInfo;
             pictureInfo.pStdPictureInfo = &stdPictureInfo;


### PR DESCRIPTION
## Description

encode: drop pNext arg from VkVideoEncodeFrameInfo base ctor
VulkanSDK: add library path for ld

## Type of change

bug fix

## Issue (optional)

Fix #202 

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-e6064cf077) / Ubuntu 24.04.4 LTS

Total Tests:    74
Passed:         52
Crashed:         0
Failed:          0
Not Supported:  13
Skipped:         9 (in skip list)
Success Rate: 100.0%
## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
