### PR TITLE
tests: add av1 10 bits encode test vector

### DIFF
--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -246,6 +246,21 @@
       "source_filepath": "video/yuv/352x288_15_i420.yuv"
     },
     {
+      "name": "av1_main_profile_10bit",
+      "codec": "av1",
+      "profile": "main",
+      "extra_args": [
+        "--inputBpp",
+        "10"
+      ],
+      "description": "Test AV1 Main profile 10-bit encoding",
+      "width": 352,
+      "height": 288,
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/352x288_420_10le.yuv",
+      "source_checksum": "c7d9ec2b39be350011086d52b3f973277cfcbbddf7c925a0ddde4b835229ddee",
+      "source_filepath": "video/yuv/352x288_15_i420_10le.yuv"
+    },
+    {
       "name": "av1_ip_gop",
       "codec": "av1",
       "profile": "main",


### PR DESCRIPTION
## Description

Add encode in 10 bits

## Type of change

tests

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 4060 Ti / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         68
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         1 (in skip list)
Success Rate: 100.0%


### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.0.6 (git-0e095aab43) / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         67
Crashed:         0
Failed:          0
Not Supported:   8
Skipped:         4 (in skip list)
Success Rate: 100.0%


## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
