### PR TITLE
tests: update checksum for 352x288_i420_10le

### DIFF
--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -178,8 +178,8 @@
       "width": 352,
       "height": 288,
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/352x288_420_10le.yuv",
-      "source_checksum": "cd04579c7115e33d01a874f4167a99ba73e165eb5086b5ffa66a8b018e13efb0",
-      "source_filepath": "video/yuv/352x288_15_i420_10le.yuv"
+      "source_checksum": "c7d9ec2b39be350011086d52b3f973277cfcbbddf7c925a0ddde4b835229ddee",
+      "source_filepath": "video/yuv/352x288_i420_10le.yuv"
     },
     {
       "name": "h265_ip_gop",


### PR DESCRIPTION
## Description

The  samples changed in google cloud storage to avoid issues with copyrights

## Type of change

cleanup 

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    78
Passed:         62
Crashed:         0
Failed:          0
Not Supported:  15
Skipped:         1 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
