### PR TITLE
tests: use new samples with FT(FishTank) prefix

### DIFF
--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -256,9 +256,9 @@
       "description": "Test AV1 Main profile 10-bit encoding",
       "width": 352,
       "height": 288,
-      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/352x288_420_10le.yuv",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_352x288_420_10le.yuv",
       "source_checksum": "c7d9ec2b39be350011086d52b3f973277cfcbbddf7c925a0ddde4b835229ddee",
-      "source_filepath": "video/yuv/352x288_15_i420_10le.yuv"
+      "source_filepath": "video/yuv/352x288_i420_10le.yuv"
     },
     {
       "name": "av1_ip_gop",
@@ -297,7 +297,7 @@
       "description": "Test H.264 encoding rejects resolution above hardware maximum",
       "width": 7680,
       "height": 4320,
-      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/7680x4320_420_8le.yuv",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_7680x4320_420_8le.yuv",
       "source_checksum": "8d12097d0ad9d8eb89a626b394df6c84213efe3f6c29823d345a564a1e8ec762",
       "source_filepath": "video/yuv/7680x4320_420_8le.yuv"
     },
@@ -322,7 +322,7 @@
       "description": "Test H.265 encoding rejects resolution above hardware maximum",
       "width": 7680,
       "height": 4320,
-      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/7680x4320_420_8le.yuv",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_7680x4320_420_8le.yuv",
       "source_checksum": "8d12097d0ad9d8eb89a626b394df6c84213efe3f6c29823d345a564a1e8ec762",
       "source_filepath": "video/yuv/7680x4320_420_8le.yuv"
     },
@@ -347,7 +347,7 @@
       "description": "Test AV1 encoding rejects resolution above hardware maximum",
       "width": 7680,
       "height": 4320,
-      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/7680x4320_420_8le.yuv",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_7680x4320_420_8le.yuv",
       "source_checksum": "8d12097d0ad9d8eb89a626b394df6c84213efe3f6c29823d345a564a1e8ec762",
       "source_filepath": "video/yuv/7680x4320_420_8le.yuv"
     },


### PR DESCRIPTION
## Description

Update samples to download the right file with prefix FT_. As before the yuv samples had to use a copyright free stream, new samples have been generated using a tool from nvidia with fishes.
The former samples are still in use by some version of CTS, so the new files have the format: FT_widthXheight_xxx.yuv

## Type of change

bug fix

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.1.0 (git-1d7b6318b9) / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  19
Skipped:         6 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
