### PR TITLE
tests: update proper uri for 10le sample

### DIFF
--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -177,7 +177,7 @@
       "description": "Test H.265 Main10 profile encoding",
       "width": 352,
       "height": 288,
-      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/352x288_420_10le.yuv",
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_352x288_420_10le.yuv",
       "source_checksum": "c7d9ec2b39be350011086d52b3f973277cfcbbddf7c925a0ddde4b835229ddee",
       "source_filepath": "video/yuv/352x288_i420_10le.yuv"
     },


### PR DESCRIPTION
## Description

One sample was missing to use the new sample URI with FT prefix.

## Type of change

bug fix

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.1.0 (git-1d7b6318b9) / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  19
Skipped:         6 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
