### PR TITLE
tests: add --validate to enable the Vulkan validation layer

### DIFF
--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -19,6 +19,7 @@ limitations under the License.
 
 import fnmatch
 import json
+import os
 import shutil
 import subprocess
 import time
@@ -61,6 +62,14 @@ WIN_ASSERT_ABORT_SIGNED = -1073741819  # Assert/abort (signed int32)
 WIN_COMMON_CRASH_CODES = (-1, 1, 3, 22)    # Common crash return codes
 
 
+def _has_validation_messages(output: str) -> bool:
+    """Return True if the output contains Vulkan validation layer messages."""
+    if not output:
+        return False
+    return ("VUID-" in output) or ("Validation Error" in output) or \
+           ("Validation Warning" in output)
+
+
 # pylint: disable=too-many-public-methods,too-many-instance-attributes
 class VulkanVideoTestFrameworkBase:
     """Base class for Vulkan Video test frameworks providing common
@@ -71,6 +80,7 @@ class VulkanVideoTestFrameworkBase:
         self.work_dir = options.get('work_dir')
         self.device_id = options.get('device_id')
         self.verbose = options.get('verbose', False)
+        self.validate = options.get('validate', False)
 
         ignore_skip_list = options.get('ignore_skip_list', False)
         only_skipped = options.get('only_skipped', False)
@@ -557,6 +567,10 @@ class VulkanVideoTestFrameworkBase:
                 )
             if cwd is not None:
                 subprocess_kwargs['cwd'] = str(cwd)
+            if self.validate:
+                env = os.environ.copy()
+                env['VK_INSTANCE_LAYERS'] = 'VK_LAYER_KHRONOS_validation'
+                subprocess_kwargs['env'] = env
 
             result = subprocess.run(cmd, check=False, **subprocess_kwargs)
             self._detect_driver_from_output(result.stdout, result.stderr)
@@ -879,6 +893,11 @@ class VulkanVideoTestFrameworkBase:
 
         if result.status in (VideoTestStatus.CRASH, VideoTestStatus.ERROR):
             print(f"   Command: {result.command_line}")
+            print_command_output(result)
+        elif self.validate and (
+                _has_validation_messages(result.stdout) or
+                _has_validation_messages(result.stderr)):
+            print("   ⚠️  Vulkan validation layer reported messages:")
             print_command_output(result)
         elif self.verbose and (result.stdout or result.stderr):
             print_command_output(result)

--- a/tests/vvs_test_runner.py
+++ b/tests/vvs_test_runner.py
@@ -145,6 +145,7 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
             'extended': options.get('extended', False),
             'codec_filter': options.get('codec_filter'),
             'test_pattern': options.get('test_pattern'),
+            'validate': options.get('validate', False),
         }
 
         if encoder_path and Path(encoder_path).exists():
@@ -675,6 +676,10 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--verbose", "-v", action="store_true",
         help="Show command lines being executed")
     parser.add_argument(
+        "--validate", action="store_true",
+        help="Enable the Vulkan validation layer for each test by exporting "
+             "VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation")
+    parser.add_argument(
         "--keep-files", action="store_true",
         help="Keep output artifacts after testing")
     parser.add_argument(
@@ -830,6 +835,7 @@ def run_framework_tests(args: argparse.Namespace, encoder_path: str,
         work_dir=args.work_dir,
         device_id=device_id,
         verbose=args.verbose,
+        validate=args.validate,
         keep_files=args.keep_files,
         no_auto_download=args.no_auto_download,
         skip_list=args.skip_list,


### PR DESCRIPTION


## Description

When --validate is passed, export
VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
into each test subprocess environment so the validation layer is loaded. When the layer reports messages (VUID-/Validation Error/Warning), surface the captured output even on PASS so validation issues are not silently swallowed.

## Type of change

feature

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         62
Crashed:         0
Failed:          0
Not Supported:  16
Skipped:         1 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
