### PR TITLE
VkVideoEncoder: set layerCount to 0 for DEFAULT/DISABLED rate control mode

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -1854,8 +1854,14 @@ VkResult VkVideoEncoder::HandleCtrlCmd(VkSharedBaseObj<VkVideoEncodeFrameInfo>& 
             encodeFrameInfo->rateControlLayersInfo[layerIndx].sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR;
         }
 
-        encodeFrameInfo->rateControlInfo.pLayers = encodeFrameInfo->rateControlLayersInfo;
-        encodeFrameInfo->rateControlInfo.layerCount = 1;
+        if (encodeFrameInfo->rateControlInfo.rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR &&
+            encodeFrameInfo->rateControlInfo.rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) {
+            encodeFrameInfo->rateControlInfo.pLayers = encodeFrameInfo->rateControlLayersInfo;
+            encodeFrameInfo->rateControlInfo.layerCount = 1;
+        } else {
+            encodeFrameInfo->rateControlInfo.pLayers = nullptr;
+            encodeFrameInfo->rateControlInfo.layerCount = 0;
+        }
         m_beginRateControlInfo = encodeFrameInfo->rateControlInfo;
 
         if (pNext != nullptr) {


### PR DESCRIPTION
… modes



## Description

Per VUID-VkVideoEncodeRateControlInfoKHR-rateControlMode-08248, layerCount must be 0 when rateControlMode is
VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR
or VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR.

## Type of change

VVL bug fix

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.1.2 (git-c653d1509f) / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  19
Skipped:         6 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
