### PR TITLE
encode: dump full encode capabilities under --verbose

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -776,7 +776,6 @@ public:
     uint32_t validateVerbose : 1;
     uint32_t verbose : 1;
     uint32_t verboseFrameStruct : 1;
-    uint32_t verboseMsg : 1;
     uint32_t enableFramePresent : 1;
     uint32_t enableFrameDirectModePresent : 1;
     uint32_t enableHwLoadBalancing : 1;
@@ -877,7 +876,6 @@ public:
     , validateVerbose(false)
     , verbose(false)
     , verboseFrameStruct(false)
-    , verboseMsg(false)
     , enableFramePresent(false)
     , enableFrameDirectModePresent(false)
     , enableHwLoadBalancing(false)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <iomanip>
 #include "VkVideoEncoder/VkEncoderConfigAV1.h"
 
 #define READ_PARAM(i, param, type) {                            \
@@ -211,15 +212,23 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
         return result;
     }
 
-    if (verboseMsg) {
-        std::cout << "\t\t\t" << VkVideoCoreProfile::CodecToName(codec) << "encode capabilities: " << std::endl;
-        std::cout << "\t\t\t" << "minBitstreamBufferOffsetAlignment: " << videoCapabilities.minBitstreamBufferOffsetAlignment << std::endl;
-        std::cout << "\t\t\t" << "minBitstreamBufferSizeAlignment: " << videoCapabilities.minBitstreamBufferSizeAlignment << std::endl;
-        std::cout << "\t\t\t" << "pictureAccessGranularity: " << videoCapabilities.pictureAccessGranularity.width << " x " << videoCapabilities.pictureAccessGranularity.height << std::endl;
-        std::cout << "\t\t\t" << "minExtent: " << videoCapabilities.minCodedExtent.width << " x " << videoCapabilities.minCodedExtent.height << std::endl;
-        std::cout << "\t\t\t" << "maxExtent: " << videoCapabilities.maxCodedExtent.width  << " x " << videoCapabilities.maxCodedExtent.height << std::endl;
-        std::cout << "\t\t\t" << "maxDpbSlots: " << videoCapabilities.maxDpbSlots << std::endl;
-        std::cout << "\t\t\t" << "maxActiveReferencePictures: " << videoCapabilities.maxActiveReferencePictures << std::endl;
+    if (verbose) {
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                          AV1 Encoder Capabilities" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "flags" << ": 0x" << std::hex << av1EncodeCapabilities.flags << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxSingleReferenceCount" << ": " << av1EncodeCapabilities.maxSingleReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "singleReferenceNameMask" << ": 0x" << std::hex << av1EncodeCapabilities.singleReferenceNameMask << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxUnidirectionalCompoundReferenceCount" << ": " << av1EncodeCapabilities.maxUnidirectionalCompoundReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxUnidirectionalCompoundGroup1ReferenceCount" << ": " << av1EncodeCapabilities.maxUnidirectionalCompoundGroup1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "unidirectionalCompoundReferenceNameMask" << ": 0x" << std::hex << av1EncodeCapabilities.unidirectionalCompoundReferenceNameMask << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxBidirectionalCompoundReferenceCount" << ": " << av1EncodeCapabilities.maxBidirectionalCompoundReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxBidirectionalCompoundGroup1ReferenceCount" << ": " << av1EncodeCapabilities.maxBidirectionalCompoundGroup1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxBidirectionalCompoundGroup2ReferenceCount" << ": " << av1EncodeCapabilities.maxBidirectionalCompoundGroup2ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "bidirectionalCompoundReferenceNameMask" << ": 0x" << std::hex << av1EncodeCapabilities.bidirectionalCompoundReferenceNameMask << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxTemporalLayerCount" << ": " << av1EncodeCapabilities.maxTemporalLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxSpatialLayerCount" << ": " << av1EncodeCapabilities.maxSpatialLayerCount << std::endl;
     }
 
     result = VulkanVideoCapabilities::GetPhysicalDeviceVideoEncodeQualityLevelProperties<VkVideoEncodeAV1QualityLevelPropertiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR>
@@ -232,27 +241,30 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
         return result;
     }
 
-    if (verboseMsg) {
-        std::cout << "\t\t" << VkVideoCoreProfile::CodecToName(codec) << "encode quality level properties: " << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlMode : " << qualityLevelProperties.preferredRateControlMode << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlLayerCount : " << qualityLevelProperties.preferredRateControlLayerCount << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlFlags : " << av1QualityLevelProperties.preferredRateControlFlags << std::endl;
-        std::cout << "\t\t\t" << "preferredGopFrameCount : " << av1QualityLevelProperties.preferredGopFrameCount << std::endl;
-        std::cout << "\t\t\t" << "preferredKeyFramePeriod : " << av1QualityLevelProperties.preferredKeyFramePeriod << std::endl;
-        std::cout << "\t\t\t" << "preferredConsecutiveBipredictiveFrameCount : " << av1QualityLevelProperties.preferredConsecutiveBipredictiveFrameCount << std::endl;
-        std::cout << "\t\t\t" << "preferredTemporalLayerCount : " << av1QualityLevelProperties.preferredTemporalLayerCount << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQIndex.intraQIndex : " << av1QualityLevelProperties.preferredConstantQIndex.intraQIndex << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQIndex.predictiveQIndex : " << av1QualityLevelProperties.preferredConstantQIndex.predictiveQIndex << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQIndex.bipredictiveQIndex : " << av1QualityLevelProperties.preferredConstantQIndex.bipredictiveQIndex << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxSingleReferenceCount : " << av1QualityLevelProperties.preferredMaxSingleReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredSingleReferenceNameMask : " << av1QualityLevelProperties.preferredSingleReferenceNameMask << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxUnidirectionalCompoundReferenceCount : " << av1QualityLevelProperties.preferredMaxUnidirectionalCompoundReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxUnidirectionalCompoundGroup1ReferenceCount : " << av1QualityLevelProperties.preferredMaxUnidirectionalCompoundGroup1ReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredUnidirectionalCompoundReferenceNameMask : " << av1QualityLevelProperties.preferredUnidirectionalCompoundReferenceNameMask << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxBidirectionalCompoundReferenceCount : " << av1QualityLevelProperties.preferredMaxBidirectionalCompoundReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxBidirectionalCompoundGroup1ReferenceCount : " << av1QualityLevelProperties.preferredMaxBidirectionalCompoundGroup1ReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxBidirectionalCompoundGroup2ReferenceCount : " << av1QualityLevelProperties.preferredMaxBidirectionalCompoundGroup2ReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredBidirectionalCompoundReferenceNameMask : " << av1QualityLevelProperties.preferredBidirectionalCompoundReferenceNameMask << std::endl;
+    if (verbose) {
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                     AV1 Encoder Quality Level Properties" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlMode" << ": " << qualityLevelProperties.preferredRateControlMode << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlLayerCount" << ": " << qualityLevelProperties.preferredRateControlLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlFlags" << ": " << av1QualityLevelProperties.preferredRateControlFlags << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredGopFrameCount" << ": " << av1QualityLevelProperties.preferredGopFrameCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredKeyFramePeriod" << ": " << av1QualityLevelProperties.preferredKeyFramePeriod << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConsecutiveBipredictiveFrameCount" << ": " << av1QualityLevelProperties.preferredConsecutiveBipredictiveFrameCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredTemporalLayerCount" << ": " << av1QualityLevelProperties.preferredTemporalLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQIndex.intraQIndex" << ": " << av1QualityLevelProperties.preferredConstantQIndex.intraQIndex << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQIndex.predictiveQIndex" << ": " << av1QualityLevelProperties.preferredConstantQIndex.predictiveQIndex << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQIndex.bipredictiveQIndex" << ": " << av1QualityLevelProperties.preferredConstantQIndex.bipredictiveQIndex << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxSingleReferenceCount" << ": " << av1QualityLevelProperties.preferredMaxSingleReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredSingleReferenceNameMask" << ": " << av1QualityLevelProperties.preferredSingleReferenceNameMask << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxUnidirectionalCompoundReferenceCount" << ": " << av1QualityLevelProperties.preferredMaxUnidirectionalCompoundReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxUnidirectionalCompoundGroup1ReferenceCount" << ": " << av1QualityLevelProperties.preferredMaxUnidirectionalCompoundGroup1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredUnidirectionalCompoundReferenceNameMask" << ": " << av1QualityLevelProperties.preferredUnidirectionalCompoundReferenceNameMask << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxBidirectionalCompoundReferenceCount" << ": " << av1QualityLevelProperties.preferredMaxBidirectionalCompoundReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxBidirectionalCompoundGroup1ReferenceCount" << ": " << av1QualityLevelProperties.preferredMaxBidirectionalCompoundGroup1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxBidirectionalCompoundGroup2ReferenceCount" << ": " << av1QualityLevelProperties.preferredMaxBidirectionalCompoundGroup2ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredBidirectionalCompoundReferenceNameMask" << ": " << av1QualityLevelProperties.preferredBidirectionalCompoundReferenceNameMask << std::endl;
     }
 
     if (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_FLAG_BITS_MAX_ENUM_KHR) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <iomanip>
 #include "VkVideoEncoder/VkEncoderConfigH264.h"
 #include "VkVideoEncoder/VkVideoEncoderH264.h"
 
@@ -414,16 +415,24 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
         return result;
     }
 
-    if (verboseMsg) {
-        std::cout << "\t\t\t" << VkVideoCoreProfile::CodecToName(codec) << "encode capabilities: " << std::endl;
-        std::cout << "\t\t\t" << "minBitstreamBufferOffsetAlignment: " << videoCapabilities.minBitstreamBufferOffsetAlignment << std::endl;
-        std::cout << "\t\t\t" << "minBitstreamBufferSizeAlignment: " << videoCapabilities.minBitstreamBufferSizeAlignment << std::endl;
-        std::cout << "\t\t\t" << "pictureAccessGranularity: " << videoCapabilities.pictureAccessGranularity.width << " x " << videoCapabilities.pictureAccessGranularity.height << std::endl;
-        std::cout << "\t\t\t" << "minExtent: " << videoCapabilities.minCodedExtent.width << " x " << videoCapabilities.minCodedExtent.height << std::endl;
-        std::cout << "\t\t\t" << "maxExtent: " << videoCapabilities.maxCodedExtent.width  << " x " << videoCapabilities.maxCodedExtent.height << std::endl;
-        std::cout << "\t\t\t" << "maxDpbSlots: " << videoCapabilities.maxDpbSlots << std::endl;
-        std::cout << "\t\t\t" << "maxActiveReferencePictures: " << videoCapabilities.maxActiveReferencePictures << std::endl;
-        std::cout << "\t\t\t" << "maxBPictureL0ReferenceCount: " << h264EncodeCapabilities.maxBPictureL0ReferenceCount << std::endl;
+    if (verbose) {
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                          H.264 Encoder Capabilities" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "flags" << ": 0x" << std::hex << h264EncodeCapabilities.flags << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxLevelIdc" << ": " << h264EncodeCapabilities.maxLevelIdc << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxSliceCount" << ": " << h264EncodeCapabilities.maxSliceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxPPictureL0ReferenceCount" << ": " << h264EncodeCapabilities.maxPPictureL0ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxBPictureL0ReferenceCount" << ": " << h264EncodeCapabilities.maxBPictureL0ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxL1ReferenceCount" << ": " << h264EncodeCapabilities.maxL1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxTemporalLayerCount" << ": " << h264EncodeCapabilities.maxTemporalLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "expectDyadicTemporalLayerPattern" << ": " << h264EncodeCapabilities.expectDyadicTemporalLayerPattern << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "minQp" << ": " << h264EncodeCapabilities.minQp << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxQp" << ": " << h264EncodeCapabilities.maxQp << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "prefersGopRemainingFrames" << ": " << h264EncodeCapabilities.prefersGopRemainingFrames << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "requiresGopRemainingFrames" << ": " << h264EncodeCapabilities.requiresGopRemainingFrames << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "stdSyntaxFlags" << ": 0x" << std::hex << h264EncodeCapabilities.stdSyntaxFlags << std::dec << std::endl;
     }
 
     result = VulkanVideoCapabilities::GetPhysicalDeviceVideoEncodeQualityLevelProperties<VkVideoEncodeH264QualityLevelPropertiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_KHR>
@@ -436,21 +445,24 @@ VkResult EncoderConfigH264::InitDeviceCapabilities(const VulkanDeviceContext* vk
         return result;
     }
 
-    if (verboseMsg) {
-        std::cout << "\t\t" << VkVideoCoreProfile::CodecToName(codec) << "encode quality level properties: " << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlMode : " << qualityLevelProperties.preferredRateControlMode << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlLayerCount : " << qualityLevelProperties.preferredRateControlLayerCount << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlFlags : " << h264QualityLevelProperties.preferredRateControlFlags << std::endl;
-        std::cout << "\t\t\t" << "preferredGopFrameCount : " << h264QualityLevelProperties.preferredGopFrameCount << std::endl;
-        std::cout << "\t\t\t" << "preferredIdrPeriod : " << h264QualityLevelProperties.preferredIdrPeriod << std::endl;
-        std::cout << "\t\t\t" << "preferredConsecutiveBFrameCount : " << h264QualityLevelProperties.preferredConsecutiveBFrameCount << std::endl;
-        std::cout << "\t\t\t" << "preferredTemporalLayerCount : " << h264QualityLevelProperties.preferredTemporalLayerCount << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQp.qpI : " << h264QualityLevelProperties.preferredConstantQp.qpI << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQp.qpP : " << h264QualityLevelProperties.preferredConstantQp.qpP << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQp.qpB : " << h264QualityLevelProperties.preferredConstantQp.qpB << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxL0ReferenceCount : " << h264QualityLevelProperties.preferredMaxL0ReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxL1ReferenceCount : " << h264QualityLevelProperties.preferredMaxL1ReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredStdEntropyCodingModeFlag : " << h264QualityLevelProperties.preferredStdEntropyCodingModeFlag << std::endl;
+    if (verbose) {
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                    H.264 Encoder Quality Level Properties" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlMode" << ": " << qualityLevelProperties.preferredRateControlMode << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlLayerCount" << ": " << qualityLevelProperties.preferredRateControlLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlFlags" << ": " << h264QualityLevelProperties.preferredRateControlFlags << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredGopFrameCount" << ": " << h264QualityLevelProperties.preferredGopFrameCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredIdrPeriod" << ": " << h264QualityLevelProperties.preferredIdrPeriod << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConsecutiveBFrameCount" << ": " << h264QualityLevelProperties.preferredConsecutiveBFrameCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredTemporalLayerCount" << ": " << h264QualityLevelProperties.preferredTemporalLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQp.qpI" << ": " << h264QualityLevelProperties.preferredConstantQp.qpI << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQp.qpP" << ": " << h264QualityLevelProperties.preferredConstantQp.qpP << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQp.qpB" << ": " << h264QualityLevelProperties.preferredConstantQp.qpB << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxL0ReferenceCount" << ": " << h264QualityLevelProperties.preferredMaxL0ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxL1ReferenceCount" << ": " << h264QualityLevelProperties.preferredMaxL1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredStdEntropyCodingModeFlag" << ": " << h264QualityLevelProperties.preferredStdEntropyCodingModeFlag << std::endl;
     }
 
     if (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_FLAG_BITS_MAX_ENUM_KHR) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH265.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <math.h>       /* sqrt */
+#include <iomanip>
 #include "VkVideoEncoder/VkEncoderConfigH265.h"
 #include "VkVideoEncoder/VkVideoEncoderH265.h"
 
@@ -135,16 +136,27 @@ VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vk
         return result;
     }
 
-    if (verboseMsg) {
-        std::cout << "\t\t" << VkVideoCoreProfile::CodecToName(codec) << "encode capabilities: " << std::endl;
-        std::cout << "\t\t\t" << "minBitstreamBufferOffsetAlignment: " << videoCapabilities.minBitstreamBufferOffsetAlignment << std::endl;
-        std::cout << "\t\t\t" << "minBitstreamBufferSizeAlignment: " << videoCapabilities.minBitstreamBufferSizeAlignment << std::endl;
-        std::cout << "\t\t\t" << "pictureAccessGranularity: " << videoCapabilities.pictureAccessGranularity.width << " x " << videoCapabilities.pictureAccessGranularity.height << std::endl;
-        std::cout << "\t\t\t" << "minExtent: " << videoCapabilities.minCodedExtent.width << " x " << videoCapabilities.minCodedExtent.height << std::endl;
-        std::cout << "\t\t\t" << "maxExtent: " << videoCapabilities.maxCodedExtent.width  << " x " << videoCapabilities.maxCodedExtent.height << std::endl;
-        std::cout << "\t\t\t" << "maxDpbSlots: " << videoCapabilities.maxDpbSlots << std::endl;
-        std::cout << "\t\t\t" << "maxActiveReferencePictures: " << videoCapabilities.maxActiveReferencePictures << std::endl;
-        std::cout << "\t\t\t" << "maxBPictureL0ReferenceCount: " << h265EncodeCapabilities.maxBPictureL0ReferenceCount << std::endl;
+    if (verbose) {
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                          H.265 Encoder Capabilities" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "flags" << ": 0x" << std::hex << h265EncodeCapabilities.flags << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxLevelIdc" << ": " << h265EncodeCapabilities.maxLevelIdc << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxSliceSegmentCount" << ": " << h265EncodeCapabilities.maxSliceSegmentCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxTiles" << ": " << h265EncodeCapabilities.maxTiles.width << " x " << h265EncodeCapabilities.maxTiles.height << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "ctbSizes" << ": 0x" << std::hex << h265EncodeCapabilities.ctbSizes << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "transformBlockSizes" << ": 0x" << std::hex << h265EncodeCapabilities.transformBlockSizes << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxPPictureL0ReferenceCount" << ": " << h265EncodeCapabilities.maxPPictureL0ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxBPictureL0ReferenceCount" << ": " << h265EncodeCapabilities.maxBPictureL0ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxL1ReferenceCount" << ": " << h265EncodeCapabilities.maxL1ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxSubLayerCount" << ": " << h265EncodeCapabilities.maxSubLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "expectDyadicTemporalSubLayerPattern" << ": " << h265EncodeCapabilities.expectDyadicTemporalSubLayerPattern << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "minQp" << ": " << h265EncodeCapabilities.minQp << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxQp" << ": " << h265EncodeCapabilities.maxQp << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "prefersGopRemainingFrames" << ": " << h265EncodeCapabilities.prefersGopRemainingFrames << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "requiresGopRemainingFrames" << ": " << h265EncodeCapabilities.requiresGopRemainingFrames << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "stdSyntaxFlags" << ": 0x" << std::hex << h265EncodeCapabilities.stdSyntaxFlags << std::dec << std::endl;
     }
 
     result = VulkanVideoCapabilities::GetPhysicalDeviceVideoEncodeQualityLevelProperties<VkVideoEncodeH265QualityLevelPropertiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_KHR>
@@ -156,20 +168,23 @@ VkResult EncoderConfigH265::InitDeviceCapabilities(const VulkanDeviceContext* vk
         return result;
     }
 
-    if (verboseMsg) {
-        std::cout << "\t\t" << VkVideoCoreProfile::CodecToName(codec) << "encode quality level properties: " << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlMode : " << qualityLevelProperties.preferredRateControlMode << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlLayerCount : " << qualityLevelProperties.preferredRateControlLayerCount << std::endl;
-        std::cout << "\t\t\t" << "preferredRateControlFlags : " << h265QualityLevelProperties.preferredRateControlFlags << std::endl;
-        std::cout << "\t\t\t" << "preferredGopFrameCount : " << h265QualityLevelProperties.preferredGopFrameCount << std::endl;
-        std::cout << "\t\t\t" << "preferredIdrPeriod : " << h265QualityLevelProperties.preferredIdrPeriod << std::endl;
-        std::cout << "\t\t\t" << "preferredConsecutiveBFrameCount : " << h265QualityLevelProperties.preferredConsecutiveBFrameCount << std::endl;
-        std::cout << "\t\t\t" << "preferredSubLayerCount : " << h265QualityLevelProperties.preferredSubLayerCount << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQp.qpI : " << h265QualityLevelProperties.preferredConstantQp.qpI << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQp.qpP : " << h265QualityLevelProperties.preferredConstantQp.qpP << std::endl;
-        std::cout << "\t\t\t" << "preferredConstantQp.qpB : " << h265QualityLevelProperties.preferredConstantQp.qpB << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxL0ReferenceCount : " << h265QualityLevelProperties.preferredMaxL0ReferenceCount << std::endl;
-        std::cout << "\t\t\t" << "preferredMaxL1ReferenceCount : " << h265QualityLevelProperties.preferredMaxL1ReferenceCount << std::endl;
+    if (verbose) {
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                    H.265 Encoder Quality Level Properties" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlMode" << ": " << qualityLevelProperties.preferredRateControlMode << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlLayerCount" << ": " << qualityLevelProperties.preferredRateControlLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredRateControlFlags" << ": " << h265QualityLevelProperties.preferredRateControlFlags << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredGopFrameCount" << ": " << h265QualityLevelProperties.preferredGopFrameCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredIdrPeriod" << ": " << h265QualityLevelProperties.preferredIdrPeriod << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConsecutiveBFrameCount" << ": " << h265QualityLevelProperties.preferredConsecutiveBFrameCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredSubLayerCount" << ": " << h265QualityLevelProperties.preferredSubLayerCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQp.qpI" << ": " << h265QualityLevelProperties.preferredConstantQp.qpI << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQp.qpP" << ": " << h265QualityLevelProperties.preferredConstantQp.qpP << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredConstantQp.qpB" << ": " << h265QualityLevelProperties.preferredConstantQp.qpB << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxL0ReferenceCount" << ": " << h265QualityLevelProperties.preferredMaxL0ReferenceCount << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "preferredMaxL1ReferenceCount" << ": " << h265QualityLevelProperties.preferredMaxL1ReferenceCount << std::endl;
     }
 
     if (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_FLAG_BITS_MAX_ENUM_KHR) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -16,6 +16,7 @@
 
 #include <cinttypes>
 #include <functional>
+#include <iomanip>
 #include <vector>
 #include "VkVideoEncoder/VkVideoEncoder.h"
 #include "VkVideoCore/VulkanVideoCapabilities.h"
@@ -794,28 +795,23 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
         const VkVideoCapabilitiesKHR& vidCaps = encoderConfig->videoCapabilities;
         const VkVideoEncodeCapabilitiesKHR& encCaps = encoderConfig->videoEncodeCapabilities;
 
-        printf("\n");
-        printf("+-------------------------------------------+\n");
-        printf("|         Encoder Capabilities              |\n");
-        printf("+---------------------------+---------------+\n");
-        printf("| flags                     | %13u |\n", encCaps.flags);
-        printf("| minCodedExtent            | %5u x %-5u |\n",
-               vidCaps.minCodedExtent.width, vidCaps.minCodedExtent.height);
-        printf("| maxCodedExtent            | %5u x %-5u |\n",
-               vidCaps.maxCodedExtent.width, vidCaps.maxCodedExtent.height);
-        printf("| pictureAccessGranularity  | %5u x %-5u |\n",
-               vidCaps.pictureAccessGranularity.width, vidCaps.pictureAccessGranularity.height);
-        printf("| encodeInputPictureGran.   | %5u x %-5u |\n",
-               encCaps.encodeInputPictureGranularity.width, encCaps.encodeInputPictureGranularity.height);
-        printf("| maxDpbSlots               | %13u |\n", vidCaps.maxDpbSlots);
-        printf("| maxActiveRefPictures      | %13u |\n", vidCaps.maxActiveReferencePictures);
-        printf("| maxQualityLevels          | %13u |\n", encCaps.maxQualityLevels);
-        printf("| maxRateControlLayers      | %13u |\n", encCaps.maxRateControlLayers);
-        printf("| maxBitrate                | %13" PRIu64 " |\n", encCaps.maxBitrate);
-        printf("| rateControlModes          | %13u |\n", encCaps.rateControlModes);
-        printf("| minBitstreamBufferOffset  | %13" PRIu64 " |\n", vidCaps.minBitstreamBufferOffsetAlignment);
-        printf("| minBitstreamBufferSize    | %13" PRIu64 " |\n", vidCaps.minBitstreamBufferSizeAlignment);
-        printf("+---------------------------+---------------+\n");
+        const std::string sep(80, '=');
+        std::cout << sep << std::endl;
+        std::cout << "                            Encoder Capabilities" << std::endl;
+        std::cout << sep << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "flags" << ": 0x" << std::hex << encCaps.flags << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "minCodedExtent" << ": " << vidCaps.minCodedExtent.width << " x " << vidCaps.minCodedExtent.height << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxCodedExtent" << ": " << vidCaps.maxCodedExtent.width << " x " << vidCaps.maxCodedExtent.height << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "pictureAccessGranularity" << ": " << vidCaps.pictureAccessGranularity.width << " x " << vidCaps.pictureAccessGranularity.height << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "encodeInputPictureGranularity" << ": " << encCaps.encodeInputPictureGranularity.width << " x " << encCaps.encodeInputPictureGranularity.height << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxDpbSlots" << ": " << vidCaps.maxDpbSlots << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxActiveReferencePictures" << ": " << vidCaps.maxActiveReferencePictures << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxQualityLevels" << ": " << encCaps.maxQualityLevels << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxRateControlLayers" << ": " << encCaps.maxRateControlLayers << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "maxBitrate" << ": " << encCaps.maxBitrate << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "rateControlModes" << ": 0x" << std::hex << encCaps.rateControlModes << std::dec << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "minBitstreamBufferOffsetAlignment" << ": " << vidCaps.minBitstreamBufferOffsetAlignment << std::endl;
+        std::cout << "  " << std::left << std::setw(48) << "minBitstreamBufferSizeAlignment" << ": " << vidCaps.minBitstreamBufferSizeAlignment << std::endl;
     }
 
     if (encoderConfig->qualityLevel >= encoderConfig->videoEncodeCapabilities.maxQualityLevels) {


### PR DESCRIPTION
## Description

Add the full codec-specific *EncodeCapabilities struct to the existing verbose dump in InitDeviceCapabilities (AV1/H.264/H.265), alongside the common video capabilities. Fires once at session init.


No real change in behavior.

## Type of change

feature 

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         62
Crashed:         0
Failed:          0
Not Supported:  16
Skipped:         1 (in skip list)
Success Rate: 100.0%

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.1.2 (git-c653d1509f) / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         54
Crashed:         0
Failed:          0
Not Supported:  19
Skipped:         6 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
