### PR TITLE
tests: unify encoder/decoder captured-output rendering

### DIFF
--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -44,7 +44,7 @@ from tests.libs.video_test_driver_detect import (
 )
 from tests.libs.video_test_result_reporter import (
     get_status_display, print_codec_breakdown, print_detailed_results,
-    print_final_summary, print_command_output)
+    print_final_summary)
 from tests.libs.video_test_utils import DEFAULT_TEST_TIMEOUT
 
 # Exit codes from sysexits.h
@@ -592,93 +592,6 @@ class VulkanVideoTestFrameworkBase:
         except (OSError, subprocess.SubprocessError) as e:
             return create_error_result(config, str(e), command_line)
 
-    def build_decoder_command(  # pylint: disable=too-many-arguments
-        self,
-        decoder_path: Path,
-        input_file: Path,
-        *,
-        output_file: Path = None,
-        extra_decoder_args: list = None,
-        no_display: bool = True,
-    ) -> list:
-        """Build decoder command with standard options."""
-        cmd = [
-            str(decoder_path),
-            "-i", str(input_file),
-            "--verbose",
-        ]
-        has_filter_arg = (extra_decoder_args
-                          and "--enablePostProcessFilter"
-                          in extra_decoder_args)
-        if not has_filter_arg:
-            cmd.extend(["--enablePostProcessFilter", "0"])
-
-        if output_file:
-            cmd.extend(["-o", str(output_file)])
-        if no_display:
-            cmd.append("--noPresent")
-        if self.device_id is not None:
-            cmd.extend(["--deviceID", str(self.device_id)])
-        cmd.append("--noDeviceFallback")
-        if extra_decoder_args:
-            cmd.extend(extra_decoder_args)
-
-        return cmd
-
-    def run_decoder_validation(
-        self,
-        decoder_path: Path,
-        input_file: Path,
-        extra_decoder_args: list = None,
-        config: BaseTestConfig = None,
-    ) -> tuple:
-        """Validate encoded file with decoder. Returns (success, output)."""
-        if not decoder_path or not decoder_path.exists():
-            print("  ⚠️  Decoder path not valid for validation")
-            return False, "Decoder path not valid"
-
-        print(f"  🔍 Validating with decoder: {input_file.name}")
-
-        cmd = self.build_decoder_command(
-            decoder_path=decoder_path,
-            input_file=input_file,
-            output_file=None,
-            extra_decoder_args=extra_decoder_args,
-            no_display=True,
-        )
-
-        if self.verbose:
-            print(f"    Decoder command: {' '.join(cmd)}")
-
-        run_cwd = self._default_run_cwd()
-        result = self.execute_test_command(
-            cmd, config, timeout=self.timeout, cwd=run_cwd
-        )
-
-        if self.verbose:
-            if result.stdout:
-                print("    Decoder stdout:")
-                print(result.stdout)
-            if result.stderr:
-                print("    Decoder stderr:")
-                print(result.stderr)
-
-        if result.status == VideoTestStatus.SUCCESS:
-            print("  ✓ Decoder validation passed")
-            return True, None
-
-        print("  ✗ Decoder validation failed")
-        output_lines = [
-            f"status: {result.status.name}, exit code: {result.returncode}"]
-        if result.stdout:
-            for line in result.stdout.strip().split('\n')[-10:]:
-                output_lines.append(line)
-        if result.stderr:
-            for line in result.stderr.strip().split('\n')[-10:]:
-                output_lines.append(line)
-
-        return False, '\n'.join(output_lines)
-
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     # pylint: disable=too-many-locals
     def filter_test_suite(
@@ -891,23 +804,37 @@ class VulkanVideoTestFrameworkBase:
         if result.error_message:
             print(f"   Error: {result.error_message}")
 
-        if result.status in (VideoTestStatus.CRASH, VideoTestStatus.ERROR):
-            print(f"   Command: {result.command_line}")
-            print_command_output(result)
-        elif self.validate and (
-                _has_validation_messages(result.stdout) or
-                _has_validation_messages(result.stderr)):
-            print("   ⚠️  Vulkan validation layer reported messages:")
-            print_command_output(result)
-        elif self.verbose and (result.stdout or result.stderr):
-            print_command_output(result)
+        # Decide whether the captured-output blocks should be shown.
+        is_failure = result.status in (
+            VideoTestStatus.CRASH, VideoTestStatus.ERROR)
+        has_validation_msgs = self.validate and (
+            _has_validation_messages(result.stdout) or
+            _has_validation_messages(result.stderr))
+        show_output = is_failure or has_validation_msgs or self.verbose
 
-        decoder_output = result.meta.get("decoder_validation_output")
-        if decoder_output and result.status == VideoTestStatus.ERROR:
-            print("   --- Decoder validation output (last 10 lines) ---")
-            for line in decoder_output.split('\n'):
-                print(f"   | {line}")
-            print("   --- End of decoder validation output ---")
+        if is_failure:
+            print(f"   Command: {result.command_line}")
+        elif has_validation_msgs:
+            print("   ⚠️  Vulkan validation layer reported messages:")
+
+        if show_output:
+            # Subclasses supply their own labeled sections (in runtime order);
+            # fall back to a single generic block when none were provided.
+            sections = result.meta.get("output_sections") or [
+                ("Command Output", result.stdout, result.stderr)
+            ]
+            for section_label, stdout, stderr in sections:
+                if not (stdout or stderr):
+                    continue
+                print(f"   === {section_label} ===")
+                if stdout:
+                    print("   STDOUT:")
+                    for line in stdout.splitlines():
+                        print(f"     {line}")
+                if stderr:
+                    print("   STDERR:")
+                    for line in stderr.splitlines():
+                        print(f"     {line}")
 
 
 __all__ = ['VulkanVideoTestFrameworkBase']

--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -44,7 +44,7 @@ from tests.libs.video_test_driver_detect import (
 )
 from tests.libs.video_test_result_reporter import (
     get_status_display, print_codec_breakdown, print_detailed_results,
-    print_final_summary, print_command_output)
+    print_final_summary)
 from tests.libs.video_test_utils import DEFAULT_TEST_TIMEOUT
 
 # Exit codes from sysexits.h
@@ -617,99 +617,6 @@ class VulkanVideoTestFrameworkBase:
         except (OSError, subprocess.SubprocessError) as e:
             return create_error_result(config, str(e), command_line)
 
-    def build_decoder_command(  # pylint: disable=too-many-arguments
-        self,
-        decoder_path: Path,
-        input_file: Path,
-        *,
-        output_file: Path = None,
-        extra_decoder_args: list = None,
-        no_display: bool = True,
-    ) -> list:
-        """Build decoder command with standard options."""
-        cmd = [
-            str(decoder_path),
-            "-i", str(input_file),
-            "--verbose",
-        ]
-        has_filter_arg = (extra_decoder_args
-                          and "--enablePostProcessFilter"
-                          in extra_decoder_args)
-        if not has_filter_arg:
-            cmd.extend(["--enablePostProcessFilter", "0"])
-
-        if output_file:
-            cmd.extend(["-o", str(output_file)])
-        if no_display:
-            cmd.append("--noPresent")
-        if self.device_id is not None:
-            cmd.extend(["--deviceID", str(self.device_id)])
-        cmd.append("--noDeviceFallback")
-        if extra_decoder_args:
-            cmd.extend(extra_decoder_args)
-
-        return cmd
-
-    def run_decoder_validation(
-        self,
-        decoder_path: Path,
-        input_file: Path,
-        extra_decoder_args: list = None,
-        config: BaseTestConfig = None,
-    ) -> tuple:
-        """Validate encoded file with decoder.
-        Returns (success, output, status)."""
-
-        if not decoder_path or not decoder_path.exists():
-            print("  ⚠️  Decoder path not valid for validation")
-            return False, "Decoder path not valid", VideoTestStatus.ERROR
-
-        print(f"  🔍 Validating with decoder: {input_file.name}")
-
-        cmd = self.build_decoder_command(
-            decoder_path=decoder_path,
-            input_file=input_file,
-            output_file=None,
-            extra_decoder_args=extra_decoder_args,
-            no_display=True,
-        )
-
-        if self.verbose:
-            print(f"    Decoder command: {' '.join(cmd)}")
-
-        run_cwd = self._default_run_cwd()
-        result = self.execute_test_command(
-            cmd, config, timeout=self.timeout, cwd=run_cwd
-        )
-
-        if self.verbose:
-            if result.stdout:
-                print("    Decoder stdout:")
-                print(result.stdout)
-            if result.stderr:
-                print("    Decoder stderr:")
-                print(result.stderr)
-
-        if result.status == VideoTestStatus.SUCCESS:
-            print("  ✓ Decoder validation passed")
-            return True, None, result.status
-
-        if result.status != VideoTestStatus.NOT_SUPPORTED:
-            # The NOT_SUPPORTED case is reported by the caller alongside the
-            # test result, so avoid printing a duplicate warning here.
-            print("  ✗ Decoder validation failed")
-
-        output_lines = [
-            f"status: {result.status.name}, exit code: {result.returncode}"]
-        if result.stdout:
-            for line in result.stdout.strip().split('\n')[-10:]:
-                output_lines.append(line)
-        if result.stderr:
-            for line in result.stderr.strip().split('\n')[-10:]:
-                output_lines.append(line)
-
-        return False, '\n'.join(output_lines), result.status
-
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     # pylint: disable=too-many-locals
     def filter_test_suite(
@@ -923,27 +830,38 @@ class VulkanVideoTestFrameworkBase:
         if result.error_message:
             print(f"   Error: {result.error_message}")
 
-        if result.status in (VideoTestStatus.CRASH, VideoTestStatus.ERROR):
+        # Decide whether the captured-output blocks should be shown.
+        # Subclasses supply their own labeled sections (in runtime order);
+        # fall back to a single generic block when none were provided.
+        sections = result.meta.get("output_sections") or [
+            ("Command Output", result.stdout, result.stderr)
+        ]
+        is_failure = result.status in (
+            VideoTestStatus.CRASH, VideoTestStatus.ERROR)
+        has_validation_msgs = self.validate and any(
+            _has_validation_messages(stdout) or
+            _has_validation_messages(stderr)
+            for _, stdout, stderr in sections)
+        show_output = is_failure or has_validation_msgs or self.verbose
+
+        if is_failure:
             print(f"   Command: {result.command_line}")
-            print_command_output(result)
-        elif self.validate and (
-                _has_validation_messages(result.stdout) or
-                _has_validation_messages(result.stderr)):
+        elif has_validation_msgs:
             print("   ⚠️  Vulkan validation layer reported messages:")
-            print_command_output(result)
-        elif self.verbose and (result.stdout or result.stderr):
-            print_command_output(result)
 
-        if result.warning_message:
-            print(f"   ⚠️  {result.warning_message}")
-
-        decoder_output = result.meta.get("decoder_validation_output")
-        if decoder_output and (result.status == VideoTestStatus.ERROR or
-                               result.warning_message):
-            print("   --- Decoder validation output (last 10 lines) ---")
-            for line in decoder_output.split('\n'):
-                print(f"   | {line}")
-            print("   --- End of decoder validation output ---")
+        if show_output:
+            for section_label, stdout, stderr in sections:
+                if not (stdout or stderr):
+                    continue
+                print(f"   === {section_label} ===")
+                if stdout:
+                    print("   STDOUT:")
+                    for line in stdout.splitlines():
+                        print(f"     {line}")
+                if stderr:
+                    print("   STDERR:")
+                    for line in stderr.splitlines():
+                        print(f"     {line}")
 
 
 __all__ = ['VulkanVideoTestFrameworkBase']

--- a/tests/libs/video_test_framework_decode.py
+++ b/tests/libs/video_test_framework_decode.py
@@ -38,6 +38,42 @@ from tests.libs.video_test_utils import (
 )
 
 
+def build_decoder_command(  # pylint: disable=too-many-arguments
+    decoder_path: Path,
+    input_file: Path,
+    *,
+    device_id=None,
+    output_file: Path = None,
+    extra_decoder_args: list = None,
+    no_display: bool = True,
+) -> list:
+    """Build decoder command with standard options."""
+    cmd = [
+        str(decoder_path),
+        "-i", str(input_file),
+    ]
+
+    cmd.append("--verbose")
+
+    has_filter_arg = (extra_decoder_args
+                      and "--enablePostProcessFilter"
+                      in extra_decoder_args)
+    if not has_filter_arg:
+        cmd.extend(["--enablePostProcessFilter", "0"])
+
+    if output_file:
+        cmd.extend(["-o", str(output_file)])
+    if no_display:
+        cmd.append("--noPresent")
+    if device_id is not None:
+        cmd.extend(["--deviceID", str(device_id)])
+    cmd.append("--noDeviceFallback")
+    if extra_decoder_args:
+        cmd.extend(extra_decoder_args)
+
+    return cmd
+
+
 @dataclass(init=False)
 class DecodeTestSample(BaseTestConfig):
     """Configuration for decoder test cases with download capability"""
@@ -174,12 +210,13 @@ class VulkanVideoDecodeTestFramework(VulkanVideoTestFrameworkBase):
             output_file = self.results_dir / f"decoded_{config.name}.yuv"
 
         # Build decoder command using shared method
-        cmd = self.build_decoder_command(
+        cmd = build_decoder_command(
             decoder_path=self.decoder_path,
             input_file=input_file,
             output_file=output_file,
             extra_decoder_args=config.extra_args,
             no_display=not self.display,
+            device_id=self.device_id,
         )
 
         # Use base class to execute (handles subprocess details)
@@ -227,6 +264,9 @@ class VulkanVideoDecodeTestFramework(VulkanVideoTestFrameworkBase):
     def run_single_test(self, config: DecodeTestSample) -> TestResult:
         """Run a single test case - implementation for base class"""
         result = self._run_decoder_test(config)
+        result.meta["output_sections"] = [
+            ("Decoder Command Output", result.stdout, result.stderr),
+        ]
         self._validate_test_result(result)
         return result
 

--- a/tests/libs/video_test_framework_decode.py
+++ b/tests/libs/video_test_framework_decode.py
@@ -38,6 +38,41 @@ from tests.libs.video_test_utils import (
 )
 
 
+def build_decoder_command(  # pylint: disable=too-many-arguments
+    decoder_path: Path,
+    input_file: Path,
+    *,
+    device_id=None,
+    output_file: Path = None,
+    extra_decoder_args: list = None,
+    no_display: bool = True,
+) -> list:
+    """Build decoder command with standard options."""
+    cmd = [
+        str(decoder_path),
+        "-i", str(input_file),
+        "--verbose",
+    ]
+
+    has_filter_arg = (extra_decoder_args
+                      and "--enablePostProcessFilter"
+                      in extra_decoder_args)
+    if not has_filter_arg:
+        cmd.extend(["--enablePostProcessFilter", "0"])
+
+    if output_file:
+        cmd.extend(["-o", str(output_file)])
+    if no_display:
+        cmd.append("--noPresent")
+    if device_id is not None:
+        cmd.extend(["--deviceID", str(device_id)])
+    cmd.append("--noDeviceFallback")
+    if extra_decoder_args:
+        cmd.extend(extra_decoder_args)
+
+    return cmd
+
+
 @dataclass(init=False)
 class DecodeTestSample(BaseTestConfig):
     """Configuration for decoder test cases with download capability"""
@@ -174,12 +209,13 @@ class VulkanVideoDecodeTestFramework(VulkanVideoTestFrameworkBase):
             output_file = self.results_dir / f"decoded_{config.name}.yuv"
 
         # Build decoder command using shared method
-        cmd = self.build_decoder_command(
+        cmd = build_decoder_command(
             decoder_path=self.decoder_path,
             input_file=input_file,
             output_file=output_file,
             extra_decoder_args=config.extra_args,
             no_display=not self.display,
+            device_id=self.device_id,
         )
 
         # Use base class to execute (handles subprocess details)
@@ -227,6 +263,9 @@ class VulkanVideoDecodeTestFramework(VulkanVideoTestFrameworkBase):
     def run_single_test(self, config: DecodeTestSample) -> TestResult:
         """Run a single test case - implementation for base class"""
         result = self._run_decoder_test(config)
+        result.meta["output_sections"] = [
+            ("Decoder Command Output", result.stdout, result.stderr),
+        ]
         self._validate_test_result(result)
         return result
 

--- a/tests/libs/video_test_framework_encode.py
+++ b/tests/libs/video_test_framework_encode.py
@@ -34,6 +34,7 @@ from tests.libs.video_test_config_base import (
 from tests.libs.video_test_framework_base import (
     VulkanVideoTestFrameworkBase,
 )
+from tests.libs.video_test_framework_decode import build_decoder_command
 from tests.libs.video_test_fetch_sample import (
     FetchableResource,
 )
@@ -296,19 +297,15 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
             result.stderr, config
         )
 
+        result.meta["output_sections"] = [
+            ("Encoder Command Output", result.stdout, result.stderr),
+        ]
+
         # Validate encoded output with decoder if enabled
         if (self.validate_with_decoder and
                 output_file.exists() and
                 result.status == VideoTestStatus.SUCCESS):
-            validation_success, validation_output = (
-                self._validate_with_decoder(output_file, config)
-            )
-            if not validation_success:
-                # Decoder validation failed - mark encoder test as error
-                result.status = VideoTestStatus.ERROR
-                result.error_message = "Decoder validation failed"
-                # Store validation output for display after test result
-                result.meta["decoder_validation_output"] = validation_output
+            self._run_decoder_validation_stage(result, output_file, config)
 
         # Clean up output file only if test succeeded and keep_files is False
         if (output_file.exists() and
@@ -317,6 +314,27 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
             output_file.unlink()
 
         return result
+
+    def _run_decoder_validation_stage(
+        self, result: TestResult, output_file: Path, config: EncodeTestSample
+    ) -> None:
+        """Decode the encoded output and fold the outcome into result.
+
+        Appends the decoder-validation section (after the encoder's own,
+        matching runtime order) and marks the test as ERROR on failure.
+        """
+        (validation_success, validation_output,
+         decoder_stdout, decoder_stderr) = (
+            self._validate_with_decoder(output_file, config)
+        )
+        result.meta["output_sections"].append(
+            ("Decoder Validation Output", decoder_stdout, decoder_stderr)
+        )
+        if not validation_success:
+            result.status = VideoTestStatus.ERROR
+            result.error_message = "Decoder validation failed"
+            # Store failure tail for the failure-summary block
+            result.meta["decoder_validation_output"] = validation_output
 
     def _analyze_encoder_output(self, stderr: str,
                                 _config: EncodeTestSample) -> bool:
@@ -348,15 +366,48 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
             config: Encoder test configuration
 
         Returns:
-            Tuple of (success: bool, validation_output: str or None)
+            Tuple of (success: bool, failure_tail: str or None,
+                      decoder_stdout: str, decoder_stderr: str)
         """
-        # Use base class method to run decoder validation
-        return self.run_decoder_validation(
-            decoder_path=self.decoder_path,
+        decoder_path = self.decoder_path
+        if not decoder_path or not decoder_path.exists():
+            print("  ⚠️  Decoder path not valid for validation")
+            return False, "Decoder path not valid", "", ""
+
+        print(f"  🔍 Validating with decoder: {encoded_file.name}")
+
+        cmd = build_decoder_command(
+            decoder_path=decoder_path,
             input_file=encoded_file,
+            output_file=None,
             extra_decoder_args=self.decoder_args,
-            config=config,
+            no_display=True,
+            device_id=self.device_id,
         )
+
+        if self.verbose:
+            print(f"    Decoder command: {' '.join(cmd)}")
+
+        run_cwd = self._default_run_cwd()
+        result = self.execute_test_command(
+            cmd, config, timeout=self.timeout, cwd=run_cwd
+        )
+
+        if result.status == VideoTestStatus.SUCCESS:
+            print("  ✓ Decoder validation passed")
+            return True, None, result.stdout, result.stderr
+
+        print("  ✗ Decoder validation failed")
+        output_lines = [
+            f"status: {result.status.name}, exit code: {result.returncode}"]
+        if result.stdout:
+            for line in result.stdout.strip().split('\n')[-10:]:
+                output_lines.append(line)
+        if result.stderr:
+            for line in result.stderr.strip().split('\n')[-10:]:
+                output_lines.append(line)
+
+        return False, '\n'.join(output_lines), result.stdout, result.stderr
 
     def _get_output_extension(self, codec: CodecType) -> str:
         """Get appropriate file extension for codec"""

--- a/tests/libs/video_test_framework_encode.py
+++ b/tests/libs/video_test_framework_encode.py
@@ -34,6 +34,7 @@ from tests.libs.video_test_config_base import (
 from tests.libs.video_test_framework_base import (
     VulkanVideoTestFrameworkBase,
 )
+from tests.libs.video_test_framework_decode import build_decoder_command
 from tests.libs.video_test_fetch_sample import (
     FetchableResource,
 )
@@ -296,25 +297,15 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
             result.stderr, config
         )
 
+        result.meta["output_sections"] = [
+            ("Encoder Command Output", result.stdout, result.stderr),
+        ]
+
         # Validate encoded output with decoder if enabled
         if (self.validate_with_decoder and
                 output_file.exists() and
                 result.status == VideoTestStatus.SUCCESS):
-            validation_success, validation_output, validation_status = (
-                self._validate_with_decoder(output_file, config)
-            )
-            if not validation_success:
-                if validation_status == VideoTestStatus.NOT_SUPPORTED:
-                    result.warning_message = (
-                        "Decoder does not support this configuration, "
-                        "encoded output was not validated"
-                    )
-                else:
-                    # Decoder validation failed - mark encoder test as error
-                    result.status = VideoTestStatus.ERROR
-                    result.error_message = "Decoder validation failed"
-                # Store validation output for display after test result
-                result.meta["decoder_validation_output"] = validation_output
+            self._run_decoder_validation_stage(result, output_file, config)
 
         # Clean up output file only if test succeeded and keep_files is False
         if (output_file.exists() and
@@ -323,6 +314,41 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
             output_file.unlink()
 
         return result
+
+    def _run_decoder_validation_stage(
+        self, result: TestResult, output_file: Path, config: EncodeTestSample
+    ) -> None:
+        """Decode the encoded output and fold the outcome into result.
+
+        Appends the decoder-validation section (after the encoder's own,
+        matching runtime order). A decoder that cannot support the encoded
+        configuration leaves the test successful with a warning; any other
+        failure marks the test as ERROR. A decoder that is missing entirely
+        is a setup failure, reported separately from a decode failure.
+        """
+        decoder_path = self.decoder_path
+        if not decoder_path or not decoder_path.exists():
+            print("  ⚠️  Decoder path not valid for validation")
+            result.status = VideoTestStatus.ERROR
+            result.error_message = "Decoder path not valid for validation"
+            return
+
+        (validation_success, validation_status,
+         decoder_stdout, decoder_stderr) = (
+            self._validate_with_decoder(output_file, config)
+        )
+        result.meta["output_sections"].append(
+            ("Decoder Validation Output", decoder_stdout, decoder_stderr)
+        )
+        if not validation_success:
+            if validation_status == VideoTestStatus.NOT_SUPPORTED:
+                result.warning_message = (
+                    "Decoder does not support this configuration, "
+                    "encoded output was not validated"
+                )
+            else:
+                result.status = VideoTestStatus.ERROR
+                result.error_message = "Decoder validation failed"
 
     def _analyze_encoder_output(self, stderr: str,
                                 _config: EncodeTestSample) -> bool:
@@ -349,21 +375,52 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
     ) -> tuple:
         """Validate encoded output by attempting to decode it
 
+        The caller guarantees self.decoder_path exists.
+
         Args:
             encoded_file: Path to encoded video file
             config: Encoder test configuration
 
         Returns:
-            Tuple of (success: bool, validation_output: str or None,
-                      status: VideoTestStatus)
+            Tuple of (success: bool, status: VideoTestStatus,
+                      decoder_stdout: str, decoder_stderr: str)
         """
-        # Use base class method to run decoder validation
-        return self.run_decoder_validation(
+        print(f"  🔍 Validating with decoder: {encoded_file.name}")
+
+        cmd = build_decoder_command(
             decoder_path=self.decoder_path,
             input_file=encoded_file,
+            output_file=None,
             extra_decoder_args=self.decoder_args,
-            config=config,
+            no_display=True,
+            device_id=self.device_id,
         )
+
+        if self.verbose:
+            print(f"    Decoder command: {' '.join(cmd)}")
+
+        run_cwd = self._default_run_cwd()
+        result = self.execute_test_command(
+            cmd, config, timeout=self.timeout, cwd=run_cwd
+        )
+
+        if result.status == VideoTestStatus.SUCCESS:
+            print("  ✓ Decoder validation passed")
+            return True, result.status, result.stdout, result.stderr
+
+        if result.status != VideoTestStatus.NOT_SUPPORTED:
+            # NOT_SUPPORTED is reported by the caller alongside the test
+            # result, so avoid printing a duplicate warning here.
+            print("  ✗ Decoder validation failed")
+
+        # The exit status is not part of either stream; keep it with the
+        # decoder output so it survives into the printed section.
+        status_line = (
+            f"status: {result.status.name}, exit code: {result.returncode}")
+        stderr = (f"{status_line}\n{result.stderr}" if result.stderr
+                  else status_line)
+
+        return False, result.status, result.stdout, stderr
 
     def _get_output_extension(self, codec: CodecType) -> str:
         """Get appropriate file extension for codec"""

--- a/tests/libs/video_test_result_reporter.py
+++ b/tests/libs/video_test_result_reporter.py
@@ -128,33 +128,3 @@ def print_final_summary(counts: tuple, test_type: str = "") -> bool:
     else:
         print(f"\n❌ {failed} {label}TEST(S) FAILED!")
     return False
-
-
-def print_command_output(result: TestResult, max_lines: int = 0) -> None:
-    """Print stdout/stderr to aid debugging.
-
-    Args:
-        result: TestResult object
-        max_lines: Maximum lines to show (0 = unlimited)
-    """
-    print("   === Command Output ===")
-    if result.stdout:
-        print("   STDOUT:")
-        lines = result.stdout.splitlines()
-        if 0 < max_lines < len(lines):
-            for line in lines[:max_lines]:
-                print(f"     {line}")
-            print(f"     ... ({len(lines) - max_lines} more lines)")
-        else:
-            for line in lines:
-                print(f"     {line}")
-    if result.stderr:
-        print("   STDERR:")
-        lines = result.stderr.splitlines()
-        if 0 < max_lines < len(lines):
-            for line in lines[:max_lines]:
-                print(f"     {line}")
-            print(f"     ... ({len(lines) - max_lines} more lines)")
-        else:
-            for line in lines:
-                print(f"     {line}")


### PR DESCRIPTION


## Description

Move build_decoder_command into the decoder framework and reuse it
from the encoder, dropping it and the validation flow from base.
Render output via a generic meta["output_sections"] list each
framework populates, so base needs no encoder/decoder knowledge.
The encoder appends its decoder-validation output after its own,
matching runtime order. Extract the encoder validation flow into
_run_decoder_validation_stage.

## Type of change

bug fix

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    79
Passed:         62
Crashed:         0
Failed:          0
Not Supported:  16
Skipped:         1 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
