### PR TITLE
tests: update 10 bits yuv samples

### DIFF
--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -178,7 +178,7 @@
       "width": 352,
       "height": 288,
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_352x288_420_10le.yuv",
-      "source_checksum": "c7d9ec2b39be350011086d52b3f973277cfcbbddf7c925a0ddde4b835229ddee",
+      "source_checksum": "cdf694b21ebf4dd9d1d3e2321dd4a85f0a4a9cf238146f23db1cdeceaf59af0c",
       "source_filepath": "video/yuv/352x288_i420_10le.yuv"
     },
     {
@@ -257,7 +257,7 @@
       "width": 352,
       "height": 288,
       "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/FT_352x288_420_10le.yuv",
-      "source_checksum": "c7d9ec2b39be350011086d52b3f973277cfcbbddf7c925a0ddde4b835229ddee",
+      "source_checksum": "cdf694b21ebf4dd9d1d3e2321dd4a85f0a4a9cf238146f23db1cdeceaf59af0c",
       "source_filepath": "video/yuv/352x288_i420_10le.yuv"
     },
     {


### PR DESCRIPTION
## Description

The former media were encoded with p010le.
Now it is encoded in yuv420p10le.

## Type of change

bug fix

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### NVIDIA GeForce RTX 3050 Ti Laptop GPU / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    84
Passed:         63
Crashed:         0
Failed:          0
Not Supported:  20
Skipped:         1 (in skip list)
Success Rate: 100.0%

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
