### PR TITLE
EncoderDpbH264: clamp max dpb size

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderDpbH264.cpp
@@ -148,7 +148,10 @@ int32_t VkEncDpbH264::DpbSequenceStart(int32_t userDpbSize)
 
     DpbDeinit();
 
-    m_max_dpb_size = userDpbSize;
+    // m_max_dpb_size counts reference slots and is compared against MAX_DPB_SLOTS
+    // in IsDpbFull(); it must never exceed the array bound, regardless of what
+    // the requested/driver-reported DPB size is.
+    m_max_dpb_size = std::min(userDpbSize, (int32_t)MAX_DPB_SLOTS);
 
     for (i = 0; i < MAX_DPB_SLOTS + 1; i++) {
         m_DPB[i] = DpbEntryH264();


### PR DESCRIPTION


## Description

Some driver might return 17 (16+1) as maxDpbSize which is
valid but will cause an issue in VVS as 16 is the maximum
value for its h264 encoder dpb pool.

## Type of change

bug fix

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-2b62ef1a3e) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  23
Skipped:         3 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
