### PR TITLE
VkVideoEncoder: clean the deinit when the encode codec extension is not supported by the driver

### DIFF
--- a/common/libs/VkCodecUtils/VulkanDeviceContext.h
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.h
@@ -130,14 +130,24 @@ public:
                 m_mutex = &devCtx->m_transferQueueMutex;
                 break;
             case DECODE:
-                assert((queueIndex >= 0) && (queueIndex < devCtx->m_videoDecodeNumQueues));
-                m_queue = &devCtx->m_videoDecodeQueues[queueIndex];
-                m_mutex = &devCtx->m_videoDecodeQueueMutexes[queueIndex];
+                if (devCtx->m_videoDecodeNumQueues) {
+                    assert((queueIndex >= 0) && (queueIndex < devCtx->m_videoDecodeNumQueues));
+                    m_queue = &devCtx->m_videoDecodeQueues[queueIndex];
+                    m_mutex = &devCtx->m_videoDecodeQueueMutexes[queueIndex];
+                } else {
+                    m_queue = nullptr;
+                    m_mutex = nullptr;
+                }
                 break;
             case ENCODE:
-                assert((queueIndex >= 0) && (queueIndex < devCtx->m_videoEncodeNumQueues));
-                m_queue = &devCtx->m_videoEncodeQueues[queueIndex];
-                m_mutex = &devCtx->m_videoEncodeQueueMutexes[queueIndex];
+                if (devCtx->m_videoEncodeNumQueues) {
+                    assert((queueIndex >= 0) && (queueIndex < devCtx->m_videoEncodeNumQueues));
+                    m_queue = &devCtx->m_videoEncodeQueues[queueIndex];
+                    m_mutex = &devCtx->m_videoEncodeQueueMutexes[queueIndex];
+                } else {
+                    m_queue = nullptr;
+                    m_mutex = nullptr;
+                }
                 break;
             case PRESENT:
                 m_queue = &devCtx->m_presentQueue;


### PR DESCRIPTION
## Description

As h26x codec might be not supported by the driver, CreateVideoEncoder already returns a correct error result with a not supported status but fails to exit properly as the deInit runs into an assert due to a non existing queue.

Indeed with a driver not supporting h265 encode queue for example, the encode tests are failing and do not report/exit properly when detecting the missing queue. On deinit of the video encoder, there is an assert such as:

```
$ ./tests/vvs_test_runner.py -t encode_h265_default

...

*** The video codec encode h.265 is not supported! ***
STDERR:
     
ERROR: InitEncoder() failed with ret(-1000023004)
vk-video-enc-test: /home/scerveau/DEV/IGALIA/PROJECTS/VALVE/DEV/Vulkan-Video-Samples/common/libs/VkCodecUtils/VulkanDeviceContext.h:138: VulkanDeviceContext::MtQueueMutex::MtQueueMutex(const VulkanDeviceContext*, VulkanDeviceContext::QueueFamilySubmitType, int32_t): Assertion `(queueIndex >= 0) && (queueIndex < devCtx->m_videoEncodeNumQueues)' failed.

```


To avoid this issue,  `MultiThreadedQueueWaitIdle` should retrieve a null queue seen that no queue has been initialized.


## Type of change

bug fix 

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-2b62ef1a3e) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  23
Skipped:         3 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
