### PR TITLE
release: create v0.4.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,18 @@
+v0.4.4:
+  - Encoder: enable shaderc compute filter for static build allowing CTS
+    to encode AV1 properly
+  - CI: enable Windows long paths in CTS builds
+  - VVL: enable VK_KHR_video_encode_intra_refresh (--intraRefreshMode)
+    and emit one slice per partition for PER_PARTITION intra-refresh on
+    H.264 and H.265
+  - VVL: enable VK_KHR_video_encode_quantization_map (--qpMap)
+  - VVL: clamp max DPB size, map capability rejections to specific
+    unsupported VkResults, and simplify pNext chaining
+  - Encoder: dump full encode capabilities under --verbose, set layerCount
+    to 0 for DEFAULT/DISABLED rate control modes
+  - Tests: add intra-refresh and qpMap samples (H.265, AV1), AV1 10-bit
+    encode vector, VP9 skip test, --validate flag, and CSV result export
+
 v0.4.3:
   - Encoder: fix DPB heap-buffer-overflow and add bounds checking across
     all codecs; clean up pNext chaining and restore CPU fallback

--- a/common/include/VkVSCommon.h
+++ b/common/include/VkVSCommon.h
@@ -10,7 +10,7 @@ extern "C" {
 // Version information
 #define VKVS_VERSION_MAJOR 0
 #define VKVS_VERSION_MINOR 4
-#define VKVS_VERSION_PATCH 3
+#define VKVS_VERSION_PATCH 4
 
 // Helper macros for version string construction (prefixed to avoid reserved identifier issues)
 #define VKVS_STRINGIFY(x) #x


### PR DESCRIPTION
## Description

v0.4.4:
  - Encoder: enable shaderc compute filter for static build fixing an issue
    with CTS builds
  - CI: enable Windows long paths in CTS builds
  - VVL: enable VK_KHR_video_encode_intra_refresh (--intraRefreshMode)
    and emit one slice per partition for PER_PARTITION intra-refresh on
    H.264 and H.265
  - VVL: enable VK_KHR_video_encode_quantization_map (--qpMap)
  - VVL: clamp max DPB size, map capability rejections to specific
    unsupported VkResults, and simplify pNext chaining
  - Encoder: dump full encode capabilities under --verbose, set layerCount
    to 0 for DEFAULT/DISABLED rate control modes
  - Tests: add intra-refresh and qpMap samples (H.265, AV1), AV1 10-bit
    encode vector, VP9 skip test, --validate flag, and CSV result export

## Type of change

release

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-2b62ef1a3e) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  23
Skipped:         3 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
