### PR TITLE
encoder: default msbShift for >8-bit input

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -663,6 +663,10 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
         return -1;
     }
 
+    if (input.msbShift < 0 && input.bpp > 8) {
+        input.msbShift = static_cast<int8_t>(16 - input.bpp);
+    }
+
     frameCount = inputFileHandler.GetFrameCount(input.width, input.height, input.bpp, input.chromaSubsampling);
 
     if (numFrames == 0 || numFrames > frameCount) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -217,12 +217,9 @@ VkResult VkVideoEncoder::LoadNextFrame(VkSharedBaseObj<VkVideoEncodeFrameInfo>& 
                         width, height);
             }
         } else if (m_encoderConfig->input.bpp == 10 || m_encoderConfig->input.bpp == 12) {
-            int shiftBits = 0;
-            if (m_encoderConfig->input.msbShift >= 0) {
-                shiftBits = m_encoderConfig->input.msbShift;
-            } else {
-                shiftBits = 16 - m_encoderConfig->input.bpp;
-            }
+            // msbShift is normalized to a non-negative value for bpp > 8 during
+            // argument parsing
+            int shiftBits = m_encoderConfig->input.msbShift;
 
             if (m_encoderConfig->encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR) {
                 yCbCrConvResult = YCbCrConvUtilsCpu<uint16_t>::I444ToP444(


### PR DESCRIPTION
## Description

The compute-filter input path only shifts 10/12-bit samples into the most-significant bits when input.msbShift > 0, but the default is -1. So without an explicit --msbShift, high bit-depth input reached the encoder LSB-aligned and encoded to garbage. 

This has side-effects as well if the encoder library is used by other application like Vulkan CTS. If the application does not pass --msbShift explicitly, the result is also corrupted.

## Type of change

bug fix

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.3 (git-6984e91b5f) / Ubuntu 24.04.4 LTS

Total Tests:    86
Passed:         71
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         4 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

The issue is reproducible running the following command:
`python3 vvs_test_runner.py -t av1_main_profile_10bit --keep-files`

This will create the ivf file in: 
`$VVS_DIR/tests/results/test_output_av1_main_profile_10bit.ivf`

The generated video `test_output_av1_main_profile_10bit.ivf` can be played back using ffplay or another application. The result is a green video.

