### PR TITLE
VkVideoEncoder: add VK_KHR_video_encode_feedback2 support for AV1

### DIFF
--- a/common/include/VkVideoCore/VulkanVideoCapabilities.h
+++ b/common/include/VkVideoCore/VulkanVideoCapabilities.h
@@ -67,9 +67,10 @@ public:
                                                VkVideoEncodeCodecCapabilitiesKHR& videoCodecCapabilities,
                                                VkVideoEncodeQuantizationMapCapabilitiesKHR& quantizationMapCapabilities,
                                                VkVideoEncodeCodecQuantizationMapCapabilitiesKHR& codecQuantizationMapCapabilities,
-                                               VkVideoEncodeIntraRefreshCapabilitiesKHR& intraRefreshCapabilities) {
+                                               VkVideoEncodeIntraRefreshCapabilitiesKHR& intraRefreshCapabilities,
+                                               void* pExtCapabilities = nullptr) {
 
-        intraRefreshCapabilities = VkVideoEncodeIntraRefreshCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_CAPABILITIES_KHR, nullptr };
+        intraRefreshCapabilities = VkVideoEncodeIntraRefreshCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_CAPABILITIES_KHR, pExtCapabilities };
         codecQuantizationMapCapabilities = VkVideoEncodeCodecQuantizationMapCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_CODEC_QUANTIZATION_MAP_CAPABILITIES_KHR, &intraRefreshCapabilities };
         quantizationMapCapabilities = VkVideoEncodeQuantizationMapCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR, &codecQuantizationMapCapabilities };
         videoCodecCapabilities  = VkVideoEncodeCodecCapabilitiesKHR { VK_STRUCTURE_TYPE_VIDEO_ENCODE_CODEC_CAPABILITIES_KHR, &quantizationMapCapabilities };

--- a/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.cpp
@@ -797,6 +797,11 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
                                                                           false // videoEncodeAV1
                                                                         };
 
+        VkPhysicalDeviceVideoEncodeFeedback2FeaturesKHR feedback2Features { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_FEEDBACK_2_FEATURES_KHR,
+                                                                            nullptr,
+                                                                            false // videoEncodeFeedback2
+                                                                          };
+
         // Chain only the structures that are requested
         VkBaseInStructure* pNext = nullptr;
         if (videoCodecs & VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR) {
@@ -806,6 +811,10 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
         if (videoCodecs & VK_VIDEO_CODEC_OPERATION_DECODE_VP9_BIT_KHR) {
             videoDecodeVP9Feature.pNext = pNext;
             pNext = (VkBaseInStructure*)&videoDecodeVP9Feature;
+        }
+        if (m_videoEncodeFeedback2Enabled) {
+            feedback2Features.pNext = pNext;
+            pNext = (VkBaseInStructure*)&feedback2Features;
         }
 
         VkPhysicalDeviceTimelineSemaphoreFeatures timelineSemaphoreFeatures { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES,
@@ -844,6 +853,8 @@ VkResult VulkanDeviceContext::CreateVulkanDevice(int32_t numDecodeQueues,
                              (videoEncodeAV1Feature.videoEncodeAV1 != VK_FALSE), "videoEncodeAV1", false);
         CHECK_VULKAN_FEATURE(((videoCodecs & VK_VIDEO_CODEC_OPERATION_DECODE_VP9_BIT_KHR) != 0) ==
                              (videoDecodeVP9Feature.videoDecodeVP9 != VK_FALSE), "videoDecodeVP9", false);
+        CHECK_VULKAN_FEATURE((m_videoEncodeFeedback2Enabled != 0) ==
+                             (feedback2Features.videoEncodeFeedback2 != VK_FALSE), "videoEncodeFeedback2", false);
 
         // Validate feature support here.
         // TODO: Currntly this method is receiving all codec bits irrespective of the codec that is required to decode/encode provided input.
@@ -974,6 +985,7 @@ VulkanDeviceContext::VulkanDeviceContext()
     , m_importedDeviceHandle(false)
     , m_videoDecodeQueryResultStatusSupport(false)
     , m_videoEncodeQueryResultStatusSupport(false)
+    , m_videoEncodeFeedback2Enabled(false)
     , m_device()
     , m_gfxQueue()
     , m_computeQueue()

--- a/common/libs/VkCodecUtils/VulkanDeviceContext.h
+++ b/common/libs/VkCodecUtils/VulkanDeviceContext.h
@@ -111,6 +111,13 @@ public:
     bool    GetVideoEncodeQueryResultStatusSupport() const { return m_videoEncodeQueryResultStatusSupport; }
     VkQueueFlags GetVideoDecodeQueueFlag() const { return m_videoDecodeQueueFlags; }
     VkQueueFlags GetVideoEncodeQueueFlag() const { return m_videoEncodeQueueFlags; }
+    void SetVideoEncodeFeedback2Enabled(bool enable) {
+        m_videoEncodeFeedback2Enabled = enable;
+        if (enable) {
+            AddReqDeviceExtension(VK_KHR_VIDEO_ENCODE_FEEDBACK_2_EXTENSION_NAME);
+        }
+    }
+    bool GetVideoEncodeFeedback2Enabled() const { return m_videoEncodeFeedback2Enabled; }
     class MtQueueMutex {
 
     public:
@@ -341,6 +348,7 @@ private:
     uint32_t m_importedDeviceHandle : 1;
     uint32_t m_videoDecodeQueryResultStatusSupport : 1;
     uint32_t m_videoEncodeQueryResultStatusSupport : 1;
+    uint32_t m_videoEncodeFeedback2Enabled : 1;
     VkDevice                m_device;
     VkQueue                 m_gfxQueue;
     VkQueue                 m_computeQueue;

--- a/tests/encode_samples.json
+++ b/tests/encode_samples.json
@@ -277,6 +277,39 @@
       "source_filepath": "video/yuv/352x288_15_i420.yuv"
     },
     {
+      "name": "av1_encode_feedback",
+      "codec": "av1",
+      "profile": "main",
+      "extra_args": [
+        "--pictureFeedback",
+        "--pixelCountFeedback",
+        "--skippedPixelCountFeedback"
+      ],
+      "description": "Test AV1 picture-level encode feedback2 (qp, pixel counts)",
+      "width": 1920,
+      "height": 1080,
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/1920x1080_420_8le.yuv",
+      "source_checksum": "9cdc96522bd15977445459aa144d019029e65e76c1893c11f89666645e8afc1e",
+      "source_filepath": "video/yuv/1920x1080_420_8le.yuv"
+    },
+    {
+      "name": "av1_encode_feedback_per_partition",
+      "codec": "av1",
+      "profile": "main",
+      "extra_args": [
+        "--pictureFeedback",
+        "--enablePerPartitionFeedback",
+        "--maxPerPartitionFeedbackEntries",
+        "16"
+      ],
+      "description": "Test AV1 per-partition encode feedback2",
+      "width": 1920,
+      "height": 1080,
+      "source_url": "https://storage.googleapis.com/vulkan-video-samples/yuv/1920x1080_420_8le.yuv",
+      "source_checksum": "9cdc96522bd15977445459aa144d019029e65e76c1893c11f89666645e8afc1e",
+      "source_filepath": "video/yuv/1920x1080_420_8le.yuv"
+    },
+    {
       "name": "h264_resolution_too_small",
       "codec": "h264",
       "profile": null,

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -87,6 +87,13 @@ int main(int argc, const char* argv[])
     vkDevCtxt.AddReqDeviceExtensions(requiredDeviceExtension);
     vkDevCtxt.AddOptDeviceExtensions(optinalDeviceExtension);
 
+    bool enableFeedback2 = false;
+    if (const EncoderConfigAV1* av1Config = encoderConfig->GetEncoderConfigAV1()) {
+        enableFeedback2 = av1Config->enablePictureFeedback || av1Config->enablePixelCountFeedback ||
+                          av1Config->enableSkippedPixelCountFeedback || av1Config->enablePerPartitionFeedback;
+    }
+    vkDevCtxt.SetVideoEncodeFeedback2Enabled(enableFeedback2);
+
     /********** Start WSI instance extensions support *******************************************/
     if (encoderConfig->enableFramePresent) {
         const std::vector<VkExtensionProperties>& wsiRequiredInstanceInstanceExtensions =

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -144,6 +144,11 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
                                         Eg: 1. \"--cdef --params 3  2  1 2 9 1   2 3 7 3   3 1 4 2   4 0 3 2\"\n\
                                             2. \"--cdef --params 3  0  1 2 9 1\"\n\
                                             3. \"--cdef\"\n\
+        --pictureFeedback               Enable picture-level feedback2 output\n\
+        --pixelCountFeedback            Enable pixel count feedback2 output (intra/inter)\n\
+        --skippedPixelCountFeedback     Enable skipped pixel count feedback2 output (implies --pixelCountFeedback)\n\
+        --enablePerPartitionFeedback    Enable per-partition feedback2 output\n\
+        --maxPerPartitionFeedbackEntries <integer> : Max per-partition feedback entries to request\n\
         --lr                            Enable loop restoration filter\n\
         --params                        Enabel custom loop restoration filter configuration when followed by --lr option\n\
                                         Otherwise default loop restoration filter configuration will be used\n\

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -496,6 +496,12 @@ public:
     size_t SetFileName(const char* inputFileName)
     {
         Destroy();
+        const size_t nameLength = strlen(inputFileName);
+        if (nameLength >= sizeof(m_fileName)) {
+            fprintf(stderr, "Output file name is too long (max %zu characters): %s\n",
+                    sizeof(m_fileName) - 1, inputFileName);
+            return 0;
+        }
         strcpy(m_fileName, inputFileName);
         return OpenFile();
     }

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -500,7 +500,7 @@ public:
         return OpenFile();
     }
 
-    const char* GetFileName()
+    const char* GetFileName() const
     {
         return m_fileName;
     }
@@ -715,6 +715,7 @@ public:
     VkVideoEncodeCapabilitiesKHR videoEncodeCapabilities;
     VkVideoEncodeQuantizationMapCapabilitiesKHR quantizationMapCapabilities;
     VkVideoEncodeIntraRefreshCapabilitiesKHR intraRefreshCapabilities;
+    VkVideoEncodeFeedback2CapabilitiesKHR videoEncodeFeedback2Capabilities;
     VkVideoEncodeQualityLevelPropertiesKHR qualityLevelProperties;
     VkVideoEncodeRateControlModeFlagBitsKHR rateControlMode;
     uint32_t averageBitrate; // kbits/sec
@@ -822,6 +823,7 @@ public:
     , videoEncodeCapabilities()
     , quantizationMapCapabilities()
     , intraRefreshCapabilities()
+    , videoEncodeFeedback2Capabilities()
     , rateControlMode(VK_VIDEO_ENCODE_RATE_CONTROL_MODE_FLAG_BITS_MAX_ENUM_KHR)
     , averageBitrate()
     , maxBitrate()

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -139,6 +139,17 @@ int EncoderConfigAV1::DoParseArguments(int argc, const char* argv[])
                     READ_PARAM(i, lrConfig.LoopRestorationSize[j], uint16_t);
                 }
             }
+        } else if (args[i] == "--pictureFeedback") {
+            enablePictureFeedback = true;
+        } else if (args[i] == "--pixelCountFeedback") {
+            enablePixelCountFeedback = true;
+        } else if (args[i] == "--skippedPixelCountFeedback") {
+            enableSkippedPixelCountFeedback = true;
+            enablePixelCountFeedback = true;
+        } else if (args[i] == "--enablePerPartitionFeedback") {
+            enablePerPartitionFeedback = true;
+        } else if (args[i] == "--maxPerPartitionFeedbackEntries") {
+            READ_PARAM(i, maxPerPartitionFeedbackEntries, uint32_t);
         } else if (args[i] == "--profile"){
             if (++i >= argc) {
                 fprintf(stderr, "invalid parameter for %s\n", args[i-1].c_str());
@@ -190,6 +201,12 @@ bool EncoderConfigAV1::InitSequenceHeader(StdVideoAV1SequenceHeader *seqHdr,
 
 VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    const bool feedback2Requested = enablePictureFeedback || enablePixelCountFeedback ||
+                                    enableSkippedPixelCountFeedback || enablePerPartitionFeedback;
+    videoEncodeFeedback2Capabilities = VkVideoEncodeFeedback2CapabilitiesKHR
+        { VK_STRUCTURE_TYPE_VIDEO_ENCODE_FEEDBACK_2_CAPABILITIES_KHR, nullptr };
+    void* pExtCapabilities = feedback2Requested ? &videoEncodeFeedback2Capabilities : nullptr;
+
     VkResult result = VulkanVideoCapabilities::GetVideoEncodeCapabilities<VkVideoEncodeAV1CapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR,
                                                                           VkVideoEncodeAV1QuantizationMapCapabilitiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUANTIZATION_MAP_CAPABILITIES_KHR>
                                                         (vkDevCtx, videoCoreProfile,
@@ -198,7 +215,8 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
                                                          av1EncodeCapabilities,
                                                          quantizationMapCapabilities,
                                                          av1QuantizationMapCapabilities,
-                                                         intraRefreshCapabilities);
+                                                         intraRefreshCapabilities,
+                                                         pExtCapabilities);
     if (result != VK_SUCCESS) {
         // Distinguish between "not supported" and "actual error"
         if (IsVideoUnsupportedResult(result)) {
@@ -229,6 +247,10 @@ VkResult EncoderConfigAV1::InitDeviceCapabilities(const VulkanDeviceContext* vkD
         std::cout << "  " << std::left << std::setw(48) << "bidirectionalCompoundReferenceNameMask" << ": 0x" << std::hex << av1EncodeCapabilities.bidirectionalCompoundReferenceNameMask << std::dec << std::endl;
         std::cout << "  " << std::left << std::setw(48) << "maxTemporalLayerCount" << ": " << av1EncodeCapabilities.maxTemporalLayerCount << std::endl;
         std::cout << "  " << std::left << std::setw(48) << "maxSpatialLayerCount" << ": " << av1EncodeCapabilities.maxSpatialLayerCount << std::endl;
+        if (feedback2Requested) {
+            std::cout << "  " << std::left << std::setw(48) << "maxPerPartitionFeedbackEntries" << ": " << videoEncodeFeedback2Capabilities.maxPerPartitionFeedbackEntries << std::endl;
+            std::cout << "  " << std::left << std::setw(48) << "supportedPerPartitionEncodeFeedbackFlags" << ": 0x" << std::hex << videoEncodeFeedback2Capabilities.supportedPerPartitionEncodeFeedbackFlags << std::dec << std::endl;
+        }
     }
 
     result = VulkanVideoCapabilities::GetPhysicalDeviceVideoEncodeQualityLevelProperties<VkVideoEncodeAV1QualityLevelPropertiesKHR, VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR>

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.h
@@ -225,6 +225,12 @@ struct EncoderConfigAV1 : public EncoderConfig {
     bool                                    enableLr{};
     bool                                    customLrConfig{};
     StdVideoAV1LoopRestoration              lrConfig{};
+
+    bool                                    enablePictureFeedback{};
+    bool                                    enablePixelCountFeedback{};
+    bool                                    enableSkippedPixelCountFeedback{};
+    bool                                    enablePerPartitionFeedback{};
+    uint32_t                                maxPerPartitionFeedbackEntries{1u};
 };
 
 #endif /* VKVIDEOENCODER_VKENCODERCONFIG_AV1_H_ */

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.cpp
@@ -46,6 +46,34 @@ static size_t getFormatTexelSize(VkFormat format)
     }
 }
 
+static const char* getEncodeFeedbackFlagName(VkVideoEncodeFeedbackFlagBitsKHR flag)
+{
+    switch (flag) {
+    case VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR:
+        return "BITSTREAM_BUFFER_OFFSET";
+    case VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR:
+        return "BITSTREAM_BYTES_WRITTEN";
+    case VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_HAS_OVERRIDES_BIT_KHR:
+        return "BITSTREAM_HAS_OVERRIDES";
+    case VK_VIDEO_ENCODE_FEEDBACK_AVERAGE_QUANTIZATION_BIT_KHR:
+        return "AVERAGE_QUANTIZATION";
+    case VK_VIDEO_ENCODE_FEEDBACK_MIN_QUANTIZATION_BIT_KHR:
+        return "MIN_QUANTIZATION";
+    case VK_VIDEO_ENCODE_FEEDBACK_MAX_QUANTIZATION_BIT_KHR:
+        return "MAX_QUANTIZATION";
+    case VK_VIDEO_ENCODE_FEEDBACK_INTRA_PIXELS_BIT_KHR:
+        return "INTRA_PIXELS";
+    case VK_VIDEO_ENCODE_FEEDBACK_INTER_PIXELS_BIT_KHR:
+        return "INTER_PIXELS";
+    case VK_VIDEO_ENCODE_FEEDBACK_SKIPPED_PIXELS_BIT_KHR:
+        return "SKIPPED_PIXELS";
+    case VK_VIDEO_ENCODE_FEEDBACK_PICTURE_PARTITION_COUNT_BIT_KHR:
+        return "PICTURE_PARTITION_COUNT";
+    default:
+        return "UNKNOWN";
+    }
+}
+
 VkResult VkVideoEncoder::CreateVideoEncoder(const VulkanDeviceContext* vkDevCtx,
                                             VkSharedBaseObj<EncoderConfig>& encoderConfig,
                                             VkSharedBaseObj<VkVideoEncoder>& encoder)
@@ -1501,10 +1529,113 @@ VkResult VkVideoEncoder::InitEncoder(VkSharedBaseObj<EncoderConfig>& encoderConf
 
     VkQueryPoolVideoEncodeFeedbackCreateInfoKHR encodeFeedbackCreateInfo =
         {VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR};
+    VkQueryPoolVideoEncodePerPartitionFeedbackCreateInfoKHR perPartitionFeedbackCreateInfo =
+        {VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_CREATE_INFO_KHR};
 
-    encodeFeedbackCreateInfo.pNext = encoderConfig->videoCoreProfile.GetProfile();
-    encodeFeedbackCreateInfo.encodeFeedbackFlags = VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
-                                                   VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR;
+    VkVideoEncodeFeedbackFlagsKHR encodeFeedbackFlags =
+        VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+        VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR;
+    const VkVideoEncodeFeedbackFlagsKHR supportedFeedbackFlags =
+        encoderConfig->videoEncodeCapabilities.supportedEncodeFeedbackFlags;
+    const void* feedbackPNext = encoderConfig->videoCoreProfile.GetProfile();
+    bool perPartitionFeedbackEnabled = false;
+
+    const EncoderConfigAV1* av1Config = encoderConfig->GetEncoderConfigAV1();
+    if (av1Config != nullptr) {
+        if (av1Config->enablePictureFeedback) {
+            const VkVideoEncodeFeedbackFlagsKHR qpFeedbackFlags =
+                VK_VIDEO_ENCODE_FEEDBACK_MIN_QUANTIZATION_BIT_KHR |
+                VK_VIDEO_ENCODE_FEEDBACK_MAX_QUANTIZATION_BIT_KHR;
+            const VkVideoEncodeFeedbackFlagsKHR unsupportedQpFlags =
+                qpFeedbackFlags & ~supportedFeedbackFlags;
+            if (unsupportedQpFlags != 0) {
+                std::cout << "Warning: dropping unsupported picture feedback flags: 0x"
+                          << std::hex << unsupportedQpFlags << std::dec << std::endl;
+            }
+            encodeFeedbackFlags |= VK_VIDEO_ENCODE_FEEDBACK_AVERAGE_QUANTIZATION_BIT_KHR;
+            encodeFeedbackFlags |= (supportedFeedbackFlags & qpFeedbackFlags);
+        }
+        if (av1Config->enablePixelCountFeedback) {
+            encodeFeedbackFlags |= VK_VIDEO_ENCODE_FEEDBACK_INTRA_PIXELS_BIT_KHR |
+                                   VK_VIDEO_ENCODE_FEEDBACK_INTER_PIXELS_BIT_KHR;
+        }
+        if (av1Config->enableSkippedPixelCountFeedback) {
+            encodeFeedbackFlags |= VK_VIDEO_ENCODE_FEEDBACK_SKIPPED_PIXELS_BIT_KHR;
+        }
+
+        if (av1Config->enablePerPartitionFeedback) {
+            const VkVideoEncodeFeedback2CapabilitiesKHR& feedback2Caps =
+                encoderConfig->videoEncodeFeedback2Capabilities;
+            if (feedback2Caps.maxPerPartitionFeedbackEntries == 0) {
+                std::cerr << "Per-partition encode feedback is not supported "
+                             "by the implementation for this video profile." << std::endl;
+                return VK_ERROR_FEATURE_NOT_PRESENT;
+            }
+
+            uint32_t maxEntries = std::max(1u, av1Config->maxPerPartitionFeedbackEntries);
+            if (maxEntries > feedback2Caps.maxPerPartitionFeedbackEntries) {
+                std::cout << "Warning: clamping maxPerPartitionFeedbackEntries from " << maxEntries
+                          << " to the supported maximum of "
+                          << feedback2Caps.maxPerPartitionFeedbackEntries << std::endl;
+                maxEntries = feedback2Caps.maxPerPartitionFeedbackEntries;
+            }
+
+            const VkVideoEncodePerPartitionFeedbackFlagsKHR requestedPartitionFlags =
+                VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_STATUS_BIT_KHR |
+                VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+                VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR;
+            const VkVideoEncodePerPartitionFeedbackFlagsKHR partitionFlags =
+                requestedPartitionFlags & feedback2Caps.supportedPerPartitionEncodeFeedbackFlags;
+            if (partitionFlags != requestedPartitionFlags) {
+                std::cout << "Warning: dropping unsupported per-partition feedback flags: 0x"
+                          << std::hex << (requestedPartitionFlags & ~partitionFlags)
+                          << std::dec << std::endl;
+            }
+            if (partitionFlags == 0) {
+                std::cerr << "None of the requested per-partition feedback flags "
+                             "are supported by the implementation." << std::endl;
+                return VK_ERROR_FEATURE_NOT_PRESENT;
+            }
+
+            encodeFeedbackFlags |= VK_VIDEO_ENCODE_FEEDBACK_PICTURE_PARTITION_COUNT_BIT_KHR;
+
+            perPartitionFeedbackCreateInfo.pNext = feedbackPNext;
+            perPartitionFeedbackCreateInfo.maxPerPartitionFeedbackEntries = maxEntries;
+            perPartitionFeedbackCreateInfo.perPartitionEncodeFeedbackFlags = partitionFlags;
+            feedbackPNext = &perPartitionFeedbackCreateInfo;
+            perPartitionFeedbackEnabled = true;
+        }
+    }
+
+    encodeFeedbackCreateInfo.pNext = feedbackPNext;
+    encodeFeedbackCreateInfo.encodeFeedbackFlags = encodeFeedbackFlags;
+
+    const VkVideoEncodeFeedbackFlagsKHR unsupportedFeedbackFlags =
+        encodeFeedbackFlags & ~supportedFeedbackFlags;
+    if (unsupportedFeedbackFlags != 0) {
+        // Report each unsupported flag individually so the user can tell
+        // exactly which requested feedback the implementation lacks.
+        for (uint32_t flagBit = 1; flagBit != 0; flagBit <<= 1) {
+            if ((unsupportedFeedbackFlags & flagBit) == 0) {
+                continue;
+            }
+            std::cerr << "Requested encode feedback '"
+                      << getEncodeFeedbackFlagName(
+                             (VkVideoEncodeFeedbackFlagBitsKHR)flagBit)
+                      << "' (0x" << std::hex << flagBit << std::dec
+                      << ") is not supported by the implementation." << std::endl;
+        }
+        return VK_ERROR_FEATURE_NOT_PRESENT;
+    }
+
+    m_encodeFeedbackFlags = encodeFeedbackFlags;
+    if (perPartitionFeedbackEnabled) {
+        m_perPartitionFeedbackFlags = perPartitionFeedbackCreateInfo.perPartitionEncodeFeedbackFlags;
+        m_maxPerPartitionFeedbackEntries = perPartitionFeedbackCreateInfo.maxPerPartitionFeedbackEntries;
+    } else {
+        m_perPartitionFeedbackFlags = 0;
+        m_maxPerPartitionFeedbackEntries = 0;
+    }
 
     result = m_encodeCommandBufferPool->Configure( m_vkDevCtx,
                                                    encoderConfig->numInputImages, // numPoolNodes

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoder.h
@@ -438,6 +438,10 @@ public:
         , m_maxDpbPicturesCount(16)
         , m_minStreamBufferSize(2 * 1024 * 1024)
         , m_streamBufferSize(m_minStreamBufferSize)
+        , m_encodeFeedbackFlags(VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+                                VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR)
+        , m_perPartitionFeedbackFlags(0)
+        , m_maxPerPartitionFeedbackEntries(0)
         , m_rateControlInfo{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR }
         , m_rateControlLayersInfo{{ VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR }}
         , m_picIdxToDpb{}
@@ -706,6 +710,9 @@ protected:
     uint32_t                              m_maxDpbPicturesCount;
     size_t                                m_minStreamBufferSize;
     size_t                                m_streamBufferSize;
+    VkVideoEncodeFeedbackFlagsKHR         m_encodeFeedbackFlags;
+    VkVideoEncodePerPartitionFeedbackFlagsKHR m_perPartitionFeedbackFlags;
+    uint32_t                              m_maxPerPartitionFeedbackEntries;
     VkVideoEncodeQualityLevelInfoKHR      m_qualityLevelInfo;
     VkVideoEncodeRateControlInfoKHR       m_rateControlInfo;
     VkVideoEncodeRateControlInfoKHR       m_beginRateControlInfo;

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <chrono>
+#include <cstring>
 #include "VkVideoEncoder/VkVideoEncoderAV1.h"
 #include "VkVideoCore/VulkanVideoCapabilities.h"
 
@@ -84,6 +86,12 @@ VkResult VkVideoEncoderAV1::InitEncoderCodec(VkSharedBaseObj<EncoderConfig>& enc
     VkResult result = InitEncoder(encoderConfig);
     if (result != VK_SUCCESS) {
         fprintf(stderr, "\nERROR: InitEncoder() failed with ret(%d)\n", result);
+        return result;
+    }
+
+    result = m_feedback2Output.Init(*m_encoderConfig);
+    if (result != VK_SUCCESS) {
+        fprintf(stderr, "\nERROR: Feedback2 output init failed with ret(%d)\n", result);
         return result;
     }
 
@@ -832,12 +840,179 @@ VkResult VkVideoEncoderAV1::SubmitVideoCodingCmds(VkSharedBaseObj<VkVideoEncodeF
     return VkVideoEncoder::SubmitVideoCodingCmds(encodeFrameInfo, frameIdx, ofTotalFrames);
 }
 
+size_t VkVideoEncoderAV1::GetEncodeFeedbackResultsSize() const
+{
+    size_t dataSize = 0;
+    const VkVideoEncodeFeedbackFlagsKHR flags = m_encodeFeedbackFlags;
+
+    auto addU32 = [&dataSize]() { dataSize += sizeof(uint32_t); };
+    auto addI32 = [&dataSize]() { dataSize += sizeof(int32_t); };
+    auto addStatus = [&dataSize]() { dataSize += sizeof(VkQueryResultStatusKHR); };
+
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR) {
+        addU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR) {
+        addU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_HAS_OVERRIDES_BIT_KHR) {
+        addU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_AVERAGE_QUANTIZATION_BIT_KHR) {
+        addI32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_MIN_QUANTIZATION_BIT_KHR) {
+        addI32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_MAX_QUANTIZATION_BIT_KHR) {
+        addI32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_INTRA_PIXELS_BIT_KHR) {
+        addU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_INTER_PIXELS_BIT_KHR) {
+        addU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_SKIPPED_PIXELS_BIT_KHR) {
+        addU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_PICTURE_PARTITION_COUNT_BIT_KHR) {
+        addU32();
+    }
+
+    // Status is appended when VK_QUERY_RESULT_WITH_STATUS_BIT_KHR is used.
+    addStatus();
+
+    if (m_perPartitionFeedbackFlags != 0 && m_maxPerPartitionFeedbackEntries > 0) {
+        size_t perPartitionSize = 0;
+        if (m_perPartitionFeedbackFlags & VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_STATUS_BIT_KHR) {
+            perPartitionSize += sizeof(VkQueryResultStatusKHR);
+        }
+        if (m_perPartitionFeedbackFlags & VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR) {
+            perPartitionSize += sizeof(uint32_t);
+        }
+        if (m_perPartitionFeedbackFlags & VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR) {
+            perPartitionSize += sizeof(uint32_t);
+        }
+
+        dataSize += perPartitionSize * m_maxPerPartitionFeedbackEntries;
+    }
+
+    return dataSize;
+}
+
+VkResult VkVideoEncoderAV1::GetEncodeFeedbackResults(VkQueryPool queryPool, uint32_t querySlotId,
+                                                     EncodeFeedbackResults& results)
+{
+    const size_t dataSize = GetEncodeFeedbackResultsSize();
+    std::vector<uint8_t> buffer(dataSize);
+
+    VkResult result = m_vkDevCtx->GetQueryPoolResults(*m_vkDevCtx, queryPool, querySlotId,
+                                                      1, dataSize, buffer.data(), dataSize,
+                                                      VK_QUERY_RESULT_WITH_STATUS_BIT_KHR |
+                                                      VK_QUERY_RESULT_WAIT_BIT);
+    if (result != VK_SUCCESS) {
+        return result;
+    }
+
+    results = EncodeFeedbackResults{};
+
+    const VkVideoEncodeFeedbackFlagsKHR flags = m_encodeFeedbackFlags;
+    const uint8_t* cursor = buffer.data();
+
+    auto readU32 = [&cursor]() -> uint32_t {
+        uint32_t value = 0;
+        memcpy(&value, cursor, sizeof(value));
+        cursor += sizeof(value);
+        return value;
+    };
+    auto readI32 = [&cursor]() -> int32_t {
+        int32_t value = 0;
+        memcpy(&value, cursor, sizeof(value));
+        cursor += sizeof(value);
+        return value;
+    };
+    auto readStatus = [&cursor]() -> VkQueryResultStatusKHR {
+        VkQueryResultStatusKHR value = VK_QUERY_RESULT_STATUS_NOT_READY_KHR;
+        memcpy(&value, cursor, sizeof(value));
+        cursor += sizeof(value);
+        return value;
+    };
+
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR) {
+        results.hasBitstreamStartOffset = true;
+        results.bitstreamStartOffset = readU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR) {
+        results.hasBitstreamSize = true;
+        results.bitstreamSize = readU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_HAS_OVERRIDES_BIT_KHR) {
+        results.hasOverrides = readU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_AVERAGE_QUANTIZATION_BIT_KHR) {
+        results.hasAverageQuantization = true;
+        results.averageQuantization = readI32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_MIN_QUANTIZATION_BIT_KHR) {
+        results.hasMinQuantization = true;
+        results.minQuantization = readI32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_MAX_QUANTIZATION_BIT_KHR) {
+        results.hasMaxQuantization = true;
+        results.maxQuantization = readI32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_INTRA_PIXELS_BIT_KHR) {
+        results.hasIntraPixels = true;
+        results.intraPixels = readU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_INTER_PIXELS_BIT_KHR) {
+        results.hasInterPixels = true;
+        results.interPixels = readU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_SKIPPED_PIXELS_BIT_KHR) {
+        results.hasSkippedPixels = true;
+        results.skippedPixels = readU32();
+    }
+    if (flags & VK_VIDEO_ENCODE_FEEDBACK_PICTURE_PARTITION_COUNT_BIT_KHR) {
+        results.hasPicturePartitionCount = true;
+        results.picturePartitionCount = readU32();
+    }
+
+    results.hasStatus = true;
+    results.status = readStatus();
+
+    if (m_perPartitionFeedbackFlags != 0 && m_maxPerPartitionFeedbackEntries > 0) {
+        results.partitions.reserve(m_maxPerPartitionFeedbackEntries);
+        for (uint32_t i = 0; i < m_maxPerPartitionFeedbackEntries; ++i) {
+            Feedback2PartitionInfo partition{};
+            partition.index = i;
+
+            if (m_perPartitionFeedbackFlags & VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_STATUS_BIT_KHR) {
+                partition.hasStatus = true;
+                partition.status = readStatus();
+            }
+            if (m_perPartitionFeedbackFlags & VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR) {
+                partition.offset = readU32();
+            }
+            if (m_perPartitionFeedbackFlags & VK_VIDEO_ENCODE_PER_PARTITION_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR) {
+                partition.size = readU32();
+            }
+
+            results.partitions.push_back(partition);
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
 VkResult VkVideoEncoderAV1::AssembleBitstreamData(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo,
                                                   uint32_t frameIdx, uint32_t ofTotalFrames)
 {
     VkVideoEncodeFrameInfoAV1* pFrameInfo = GetEncodeFrameInfoAV1(encodeFrameInfo);
 
     if (pFrameInfo->bShowExistingFrame) {
+        WriteFeedback2Output(pFrameInfo, nullptr);
         WriteShowExistingFrameHeader(encodeFrameInfo);
         return VK_SUCCESS;
     }
@@ -860,23 +1035,21 @@ VkResult VkVideoEncoderAV1::AssembleBitstreamData(VkSharedBaseObj<VkVideoEncodeF
     querySlotId = (uint32_t)encodeFrameInfo->srcEncodeImageResource->GetImageIndex();
 
     // get output results
-    struct VulkanVideoEncodeStatus {
-        uint32_t bitstreamStartOffset;
-        uint32_t bitstreamSize;
-        VkQueryResultStatusKHR status;
-    } encodeResult{};
+    EncodeFeedbackResults encodeResult{};
 
     // Fetch the coded VCL data and its information
-    result = m_vkDevCtx->GetQueryPoolResults(*m_vkDevCtx, queryPool, querySlotId,
-                                             1, sizeof(encodeResult), &encodeResult, sizeof(encodeResult),
-                                             VK_QUERY_RESULT_WITH_STATUS_BIT_KHR | VK_QUERY_RESULT_WAIT_BIT);
+    result = GetEncodeFeedbackResults(queryPool, querySlotId, encodeResult);
 
-    assert(result == VK_SUCCESS);
-    assert(encodeResult.status == VK_QUERY_RESULT_STATUS_COMPLETE_KHR);
-
-    if(result != VK_SUCCESS) {
+    if (result != VK_SUCCESS) {
         fprintf(stderr, "\nRetrieveData Error: Failed to get vcl query pool results.\n");
+        assert(result == VK_SUCCESS);
         return result;
+    }
+
+    if (encodeResult.status != VK_QUERY_RESULT_STATUS_COMPLETE_KHR) {
+        fprintf(stderr, "\nencodeResult.status is (0x%x) NOT STATUS_COMPLETE! bitstreamStartOffset %u, bitstreamSize %u\n",
+                encodeResult.status, encodeResult.bitstreamStartOffset, encodeResult.bitstreamSize);
+        return VK_ERROR_UNKNOWN;
     }
 
     bool flushFrameData = (pFrameInfo->stdPictureInfo.flags.show_frame || pFrameInfo->bShowExistingFrame);
@@ -1009,7 +1182,150 @@ VkResult VkVideoEncoderAV1::AssembleBitstreamData(VkSharedBaseObj<VkVideoEncodeF
     }
     fflush(m_encoderConfig->outputFileHandler.GetFileHandle());
 
+    WriteFeedback2Output(pFrameInfo, &encodeResult);
+
     return result;
+}
+
+VkResult VkVideoEncoderAV1::Feedback2TextOutput::Init(const EncoderConfigAV1& config)
+{
+    m_pictureEnabled = config.enablePictureFeedback || config.enablePixelCountFeedback || config.enablePerPartitionFeedback;
+    m_partitionEnabled = config.enablePerPartitionFeedback;
+
+    if (!Enabled()) {
+        return VK_SUCCESS;
+    }
+
+    const char* bitstreamPath = config.outputFileHandler.GetFileName();
+    if (bitstreamPath && bitstreamPath[0] != '\0') {
+        m_path = std::string(bitstreamPath) + ".feedback.txt";
+    } else {
+        m_path = "encoder.feedback.txt";
+    }
+
+    size_t fileSize = m_file.SetFileName(m_path.c_str());
+    if (fileSize == 0) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    return VK_SUCCESS;
+}
+
+void VkVideoEncoderAV1::Feedback2TextOutput::Close()
+{
+    if (m_file.HandleIsValid()) {
+        m_file.Destroy();
+    }
+    m_path.clear();
+}
+
+void VkVideoEncoderAV1::Feedback2TextOutput::WriteFrame(const Feedback2FrameOutput& output)
+{
+    if (!Enabled() || !m_file.HandleIsValid()) {
+        return;
+    }
+
+    FILE* fileHandle = m_file.GetFileHandle();
+
+    if (m_pictureEnabled) {
+        fprintf(fileHandle, "frame %llu", (unsigned long long)output.frameIndex);
+        if (output.hasStatus) {
+            fprintf(fileHandle, " status=%d", (int)output.status);
+        }
+        if (output.hasBitstreamBufferOffset) {
+            fprintf(fileHandle, " bs_offset=%u", output.bitstreamBufferOffset);
+        }
+        if (output.hasBitstreamBytesWritten) {
+            fprintf(fileHandle, " bs_size=%u", output.bitstreamBytesWritten);
+        }
+        if (output.hasAvgQp) {
+            fprintf(fileHandle, " avgqp=%d", output.avgQp);
+        }
+        if (output.hasMinQp) {
+            fprintf(fileHandle, " minqp=%d", output.minQp);
+        }
+        if (output.hasMaxQp) {
+            fprintf(fileHandle, " maxqp=%d", output.maxQp);
+        }
+        if (output.hasIntraPixels) {
+            fprintf(fileHandle, " intra=%u", output.intraPixels);
+        }
+        if (output.hasInterPixels) {
+            fprintf(fileHandle, " inter=%u", output.interPixels);
+        }
+        if (output.hasSkippedPixels) {
+            fprintf(fileHandle, " skipped=%u", output.skippedPixels);
+        }
+        if (output.hasPicturePartitionCount) {
+            fprintf(fileHandle, " pic_partition_count=%u", output.picturePartitionCount);
+        }
+        fprintf(fileHandle, "\n");
+    }
+
+    if (m_partitionEnabled) {
+        for (const auto& partition : output.partitions) {
+            fprintf(fileHandle, "partition %u", partition.index);
+            if (partition.hasStatus) {
+                fprintf(fileHandle, " status=%d", (int)partition.status);
+            }
+            fprintf(fileHandle, " offset=%u size=%u\n", partition.offset, partition.size);
+        }
+    }
+
+    fflush(fileHandle);
+}
+
+void VkVideoEncoderAV1::WriteFeedback2Output(const VkVideoEncodeFrameInfoAV1* frameInfo,
+                                             const EncodeFeedbackResults* results)
+{
+    if (!m_feedback2Output.Enabled() || frameInfo == nullptr) {
+        return;
+    }
+
+    Feedback2FrameOutput output{};
+    output.frameIndex = frameInfo->frameInputOrderNum;
+    output.hasStatus = (results != nullptr && results->hasStatus);
+    output.status = output.hasStatus ? results->status : VK_QUERY_RESULT_STATUS_NOT_READY_KHR;
+    output.hasBitstreamBufferOffset = (results && results->hasBitstreamStartOffset);
+    output.hasBitstreamBytesWritten = (results && results->hasBitstreamSize);
+    output.bitstreamBufferOffset = output.hasBitstreamBufferOffset ? results->bitstreamStartOffset : 0;
+    output.bitstreamBytesWritten = output.hasBitstreamBytesWritten ? results->bitstreamSize : 0;
+
+    if (m_feedback2Output.PictureEnabled()) {
+        output.hasAvgQp = (results && results->hasAverageQuantization);
+        output.hasMinQp = (results && results->hasMinQuantization);
+        output.hasMaxQp = (results && results->hasMaxQuantization);
+        output.avgQp = output.hasAvgQp ? results->averageQuantization : 0;
+        output.minQp = output.hasMinQp ? results->minQuantization : 0;
+        output.maxQp = output.hasMaxQp ? results->maxQuantization : 0;
+
+        output.hasIntraPixels = (results && results->hasIntraPixels);
+        output.hasInterPixels = (results && results->hasInterPixels);
+        output.hasSkippedPixels = (results && results->hasSkippedPixels);
+        output.intraPixels = output.hasIntraPixels ? results->intraPixels : 0;
+        output.interPixels = output.hasInterPixels ? results->interPixels : 0;
+        output.skippedPixels = output.hasSkippedPixels ? results->skippedPixels : 0;
+
+        output.hasPicturePartitionCount = (results && results->hasPicturePartitionCount);
+        output.picturePartitionCount = output.hasPicturePartitionCount ? results->picturePartitionCount : 0;
+    }
+
+    if (m_feedback2Output.PartitionEnabled() && results) {
+        if (results->hasPicturePartitionCount &&
+            results->picturePartitionCount > results->partitions.size()) {
+            std::cerr << "Feedback2: picturePartitionCount (" << results->picturePartitionCount
+                      << ") exceeds allocated per-partition entries ("
+                      << results->partitions.size() << ")\n";
+        }
+        uint32_t partitionCount = results->hasPicturePartitionCount ?
+                                  results->picturePartitionCount :
+                                  static_cast<uint32_t>(results->partitions.size());
+        partitionCount = std::min(partitionCount, static_cast<uint32_t>(results->partitions.size()));
+        output.partitions.assign(results->partitions.begin(),
+                                 results->partitions.begin() + partitionCount);
+    }
+
+    m_feedback2Output.WriteFrame(output);
 }
 
 void VkVideoEncoderAV1::WriteShowExistingFrameHeader(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo)

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.h
@@ -17,7 +17,10 @@
 #ifndef _VKVIDEOENCODER_VKVIDEOENCODERAV1_H_
 #define _VKVIDEOENCODER_VKVIDEOENCODERAV1_H_
 
+#include <cstdio>
 #include <set>
+#include <string>
+#include <vector>
 #include "VkVideoEncoder/VkVideoEncoder.h"
 #include "VkVideoEncoder/VkVideoEncoderStateAV1.h"
 #include "VkVideoEncoder/VkEncoderConfigAV1.h"
@@ -182,6 +185,7 @@ public:
 protected:
     virtual ~VkVideoEncoderAV1()
     {
+        m_feedback2Output.Close();
         m_frameInfoBuffersQueue = nullptr;
         m_videoSessionParameters = nullptr;
         m_videoSession = nullptr;
@@ -193,6 +197,89 @@ protected:
     }
 
 private:
+    struct Feedback2PartitionInfo {
+        uint32_t index;
+        bool hasStatus;
+        VkQueryResultStatusKHR status;
+        uint32_t offset;
+        uint32_t size;
+    };
+
+    struct Feedback2FrameOutput {
+        uint64_t frameIndex;
+        bool hasStatus;
+        VkQueryResultStatusKHR status;
+        bool hasBitstreamBufferOffset;
+        bool hasBitstreamBytesWritten;
+        uint32_t bitstreamBufferOffset;
+        uint32_t bitstreamBytesWritten;
+        bool hasAvgQp;
+        bool hasMinQp;
+        bool hasMaxQp;
+        int32_t avgQp;
+        int32_t minQp;
+        int32_t maxQp;
+        bool hasIntraPixels;
+        bool hasInterPixels;
+        bool hasSkippedPixels;
+        uint32_t intraPixels;
+        uint32_t interPixels;
+        uint32_t skippedPixels;
+        bool hasPicturePartitionCount;
+        uint32_t picturePartitionCount;
+        std::vector<Feedback2PartitionInfo> partitions;
+    };
+
+    struct EncodeFeedbackResults {
+        uint32_t bitstreamStartOffset;
+        uint32_t bitstreamSize;
+        bool hasStatus;
+        VkQueryResultStatusKHR status;
+        bool hasBitstreamStartOffset;
+        bool hasBitstreamSize;
+        VkBool32 hasOverrides;
+        bool hasAverageQuantization;
+        bool hasMinQuantization;
+        bool hasMaxQuantization;
+        int32_t averageQuantization;
+        int32_t minQuantization;
+        int32_t maxQuantization;
+        bool hasIntraPixels;
+        bool hasInterPixels;
+        bool hasSkippedPixels;
+        uint32_t intraPixels;
+        uint32_t interPixels;
+        uint32_t skippedPixels;
+        bool hasPicturePartitionCount;
+        uint32_t picturePartitionCount;
+        std::vector<Feedback2PartitionInfo> partitions;
+    };
+
+    class Feedback2TextOutput {
+    public:
+        Feedback2TextOutput()
+            : m_pictureEnabled(false)
+            , m_partitionEnabled(false)
+            , m_path()
+            , m_file()
+        {
+        }
+
+        VkResult Init(const EncoderConfigAV1& config);
+        void Close();
+        bool Enabled() const { return m_pictureEnabled || m_partitionEnabled; }
+        bool PictureEnabled() const { return m_pictureEnabled; }
+        bool PartitionEnabled() const { return m_partitionEnabled; }
+        const std::string& GetPath() const { return m_path; }
+        void WriteFrame(const Feedback2FrameOutput& output);
+
+    private:
+        bool m_pictureEnabled;
+        bool m_partitionEnabled;
+        std::string m_path;
+        EncoderOutputFileHandler m_file;
+    };
+
     VkVideoEncodeFrameInfoAV1* GetEncodeFrameInfoAV1(VkSharedBaseObj<VkVideoEncodeFrameInfo>& encodeFrameInfo) {
         assert(VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR == encodeFrameInfo->GetCodecType());
         VkVideoEncodeFrameInfo* pEncodeFrameInfo = encodeFrameInfo;
@@ -201,11 +288,16 @@ private:
 
     void InitializeFrameHeader(StdVideoAV1SequenceHeader* pSequenceHdr, VkVideoEncodeFrameInfoAV1* pFrameInfo,
                                StdVideoAV1ReferenceName& refName);
+    VkResult GetEncodeFeedbackResults(VkQueryPool queryPool, uint32_t querySlotId, EncodeFeedbackResults& results);
+    size_t GetEncodeFeedbackResultsSize() const;
+    void WriteFeedback2Output(const VkVideoEncodeFrameInfoAV1* frameInfo,
+                              const EncodeFeedbackResults* results);
 
     VkSharedBaseObj<EncoderConfigAV1>   m_encoderConfig;
     EncoderAV1State                     m_stateAV1;
     VkEncDpbAV1*                        m_dpbAV1;
     VkSharedBaseObj<VulkanBufferPool<VkVideoEncodeFrameInfoAV1>> m_frameInfoBuffersQueue;
+    Feedback2TextOutput                 m_feedback2Output;
 
     int32_t                             m_lastKeyFrameOrderHint;
     uint32_t                            m_numBFramesToEncode;

--- a/vk_video_encoder/src/vulkan_video_encoder.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder.cpp
@@ -129,6 +129,13 @@ VkResult VulkanVideoEncoderImpl::Initialize(VkVideoCodecOperationFlagBitsKHR vid
     m_vkDevCtxt.AddReqDeviceExtensions(requiredDeviceExtension);
     m_vkDevCtxt.AddOptDeviceExtensions(optinalDeviceExtension);
 
+    bool enableFeedback2 = false;
+    if (const EncoderConfigAV1* av1Config = m_encoderConfig->GetEncoderConfigAV1()) {
+        enableFeedback2 = av1Config->enablePictureFeedback || av1Config->enablePixelCountFeedback ||
+                          av1Config->enableSkippedPixelCountFeedback || av1Config->enablePerPartitionFeedback;
+    }
+    m_vkDevCtxt.SetVideoEncodeFeedback2Enabled(enableFeedback2);
+
     result = m_vkDevCtxt.InitVulkanDevice(m_encoderConfig->appName.c_str(), VK_NULL_HANDLE,
                                           m_encoderConfig->verbose);
     if (result != VK_SUCCESS) {


### PR DESCRIPTION
## Description

Adds encoder support for the `VK_KHR_video_encode_feedback2` extension to the AV1 encode path, exposing the richer per-encode feedback the extension provides on top of the base `VK_KHR_video_encode_queue` feedback.

When any feedback2 option is enabled, the encoder now requests the `VK_KHR_video_encode_feedback2` device extension and the `videoEncodeFeedback2` feature, sets up the appropriate query pool, and parses the returned feedback into:

- **Encode status**, bitstream **size** and **offset**
- **Picture-level feedback**: average / min / max quantization
- **Pixel counts**: intra / inter / skipped
- **Picture partition count**
- **Per-partition feedback**: status, bitstream buffer offset and bytes written, up to a requested maximum number of entries

These outputs are intended for use by VK-GL-CTS to validate encoded output against the decoded bitstream, in particular for the per-partition count tests.

### New encoder CLI options

| Option | Description |
| --- | --- |
| `--pictureFeedback` | Enable picture-level feedback2 output |
| `--params` | Provide custom picture feedback params (used together with `--pictureFeedback`; otherwise defaults are used) |
| `--pixelFeedback` | Enable pixel-count feedback2 output (intra/inter) |
| `--skippedPixelFeedback` | Enable skipped-pixel feedback2 output (implies `--pixelFeedback`) |
| `--enablePerPartitionFeedback` | Enable per-partition feedback2 output |
| `--maxPerPartitionFeedbackEntries <n>` | Max per-partition feedback entries to request |

### Build requirement

`VK_KHR_video_encode_feedback2` first appears in **Vulkan-Headers v1.4.353**, so the minimum required patch version is bumped from 321 to 353. When the system SDK is older, the build fetches v1.4.353 automatically. `VkVSCommon.h` now routes Vulkan through `vulkan_interfaces.h` so the encoder library also builds under VKCTS without relying on a system Vulkan installation.

## Type of change

feature

## Tests

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.0-devel (git-16ece32984) / Debian GNU/Linux 13 (trixie)

Total Tests:    83
Passed:         69
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         4 (in skip list)
Success Rate: 100.0%

### NVIDIA GeForce RTX 4060 Ti / NVIDIA 595.44.00 / Debian GNU/Linux 13 (trixie)

Total Tests:    83
Passed:         72
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         1 (in skip list)
Success Rate: 100.0%
