### PR TITLE
encode: Some fixes to make av1 encoding work on ANV

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigAV1.cpp
@@ -435,11 +435,7 @@ bool EncoderConfigAV1::GetRateControlParameters(VkVideoEncodeRateControlInfoKHR*
     pRcLayerInfo->frameRateNumerator = frameRateNumerator;
     pRcLayerInfo->frameRateDenominator = frameRateDenominator;
 
-    if (rateControlMode == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR) {
-        pRcInfo->rateControlMode = VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR;
-    } else {
-        pRcInfo->rateControlMode = rateControlMode;
-    }
+    pRcInfo->rateControlMode = rateControlMode;
     pRcInfo->virtualBufferSizeInMs = (uint32_t)(vbvBufferSize * 1000ull / hrdBitrate);
     pRcInfo->initialVirtualBufferSizeInMs = (uint32_t)(vbvInitialDelay * 1000ull / hrdBitrate);
 

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -638,6 +638,9 @@ void VkVideoEncoderAV1::InitializeFrameHeader(StdVideoAV1SequenceHeader* pSequen
     }
     pStdPictureInfo->current_frame_id = (uint32_t)(pFrameInfo->gopPosition.encodeOrder % (1ULL << frameIdBits));
     pStdPictureInfo->order_hint = (uint8_t)(pFrameInfo->picOrderCntVal % (1 << orderHintBits));
+    // read_tx_mode(): non-lossless frames can only signal TX_MODE_LARGEST or
+    // TX_MODE_SELECT (ONLY_4X4 requires CodedLossless).
+    pStdPictureInfo->TxMode = CodedLossless ? STD_VIDEO_AV1_TX_MODE_ONLY_4X4 : STD_VIDEO_AV1_TX_MODE_SELECT;
     if (pFrameInfo->bOverlayFrame) {
         assert(pFrameInfo->bShowExistingFrame);
         pFrameInfo->frameToShowBufId = m_dpbAV1->GetOverlayRefBufId(pFrameInfo->picOrderCntVal);


### PR DESCRIPTION
## Description

Recently, I've been working on implementing av1 encoding on ANV. 
I found a couple of issues while testing it with VVS.

## Type of change

bug fix

## Tests
### NVIDIA GeForce RTX 4060 Ti / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    54
Passed:         48
Crashed:         0
Failed:          0
Not Supported:   5
Skipped:         1 (in skip list)
Success Rate: 100.0%

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-9c07493a33) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  23
Skipped:         3 (in skip list)
Success Rate: 100.0%

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.2.0-devel (git-f3852bcc94) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         69
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         4 (in skip list)
Success Rate: 100.0%

