### PR TITLE
build: fix Windows builds with the new Vulkan Loader

### DIFF
--- a/cmake/FindVulkanSDK.cmake
+++ b/cmake/FindVulkanSDK.cmake
@@ -108,6 +108,8 @@ MACRO(FIND_VULKAN_SDK minimum_major_version minimum_minor_version minimum_patch_
         # Set Vulkan Loader options to disable tests
         set(BUILD_TESTS OFF CACHE BOOL "Disable Vulkan-Loader tests" FORCE)
 
+        set(VulkanHeaders_VERSION "${minimum_major_version}.${minimum_minor_version}.${minimum_patch_version}")
+
         # Fetch the Vulkan Loader
         FetchContent_Declare(
             vulkan-loader


### PR DESCRIPTION
## Description

Vulkan-Loader configure failure (standalone build)

If the  Vulkan-Loader is updated to v1.4.353, the loader's CMakeLists reads `VulkanHeaders_VERSION` from `find_package(VulkanHeaders)`. When `FIND_VULKAN_SDK` provides the headers via FetchContent there is no installed package to find, the variable stays empty, causing the build to abort with:
 
```if given arguments: "VERSION_GREATER" "1.4.353"```

Only hosts without a system Vulkan SDK (e.g. Windows CI runners) build the loader from source, which is why Linux was unaffected.

## Type of change

bug fix

## Tests

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.3 (git-6984e91b5f) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         69
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         4 (in skip list)
Success Rate: 100.0%
