### PR TITLE
ci: stop the Windows CTS job from rebuilding the pinned release

### DIFF
--- a/.github/workflows/cts-build.yml
+++ b/.github/workflows/cts-build.yml
@@ -99,4 +99,4 @@ jobs:
       - name: Build CTS
         run: |
           cd vk-gl-cts
-          python3 scripts/check_build_sanity.py -r vs-64-debug
+          python3 scripts/check_build_sanity.py --skip-prerequisites -r vs-64-debug


### PR DESCRIPTION
## Description

The Windows job ran `check_build_sanity.py` without `--skip-prerequisites` (unlike Linux), so `fetch_sources.py --force` re-checked-out the pinned release tag over the branch sources copied in by the workflow. The job therefore always validated the pinned release and passed regardless of the PR contents. Fixed by passing `--skip-prerequisites`, matching the Linux job, since externals are already fetched by the preceding workflow step.

## Type of change

bug fix

## Tests

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.3 (git-6984e91b5f) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         69
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         4 (in skip list)
Success Rate: 100.0%

