### PR TITLE
build: update Vulkan SDK version to 1.4.358 and fix the win-arm64 CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,6 +199,7 @@ jobs:
           path: ${{ env.REPO_NAME }}-release-${{ matrix.platform }}.zip
 
   Vulkan-Video-Samples-win:
+    runs-on: ${{ matrix.os || 'windows-latest' }}
     strategy:
       matrix:
         platform: [windows-x64, windows-x64-clang, windows-x64-ffmpeg, windows-x86, windows-x86-clang, win-arm64]
@@ -221,13 +222,13 @@ jobs:
             cmake_arch: Win32
             toolset: ClangCL
           - platform: win-arm64
+            os: windows-11-arm
             arch: arm64
             cmake_arch: ARM64
-    runs-on: windows-latest
 
     steps:
       - name: Set up MSVC environment
-        if: matrix.arch != 'x64'
+        if: matrix.arch != 'x64' && matrix.os != 'windows-11-arm'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(FindVulkanSDK)
 # Search for Vulkan SDK minimum version
 set (VULKAN_SDK_MIN_MAJOR_VERSION 1)
 set (VULKAN_SDK_MIN_MINOR_VERSION 4)
-set (VULKAN_SDK_MIN_PATCH_VERSION 321)
+set (VULKAN_SDK_MIN_PATCH_VERSION 358)
 FIND_VULKAN_SDK(${VULKAN_SDK_MIN_MAJOR_VERSION} ${VULKAN_SDK_MIN_MINOR_VERSION} ${VULKAN_SDK_MIN_PATCH_VERSION})
 
 option(USE_ENCODER_SHADERC "Enable shaderc GPU compute filters for encoder (e.g. YUV conversion). Only affects the encoder build; the decoder always uses shaderc." ON)


### PR DESCRIPTION
## Description

Two issues are addressed in this PR:

- Bumps Vulkan SDK/headers requirement from 1.4.321 to 1.4.358

  - The upcoming extension **VK_KHR_video_encode_feedback2** requires Vulkan SDK 1.4.353. However, this version causes an issue with the Windows CI job which builds the Vulkan headers and loader from source.
  - The loader's CMakeLists reads VulkanHeaders_VERSION from find_package(VulkanHeaders). When FIND_VULKAN_SDK provides the headers via FetchContent there is no installed package to find, the variable
stays empty, causing the build to abort with: `if given arguments: "VERSION_GREATER" "1.4.353"`
  - A temporal workaround  in Vulkan Video Samples was proposed in #226.
  - The issue was fixed in Vulkan Loader v1.4.358 by commit [59a705](https://github.com/KhronosGroup/Vulkan-Loader/commit/59a70594de4559fd3aed73fe8ac2d6c48ca002d4).

  
- Fixes the win-arm64 CI job, which fails once the fetched Vulkan Loader is newer than 1.4.354.
  - The win-arm64 job cross-compiles: it runs on an x64 windows-latest runner and targets ARM64 via CMAKE_GENERATOR_PLATFORM. CMake does not consider this cross-compiling (CMAKE_CROSSCOMPILING stays false unless CMAKE_SYSTEM_NAME is set explicitly), so the Vulkan Loader fetched by FindVulkanSDK takes its "native" build path and executes its freshly built ARM64 asm_offset.exe helper on the x64 host:
  
      - "This version of asm_offset.exe is not compatible with the version of Windows you're running. error MSB8066: ... exited with code 216   (ERROR_EXE_MACHINE_TYPE_MISMATCH)".
  - This never failed before because loaders up to 1.4.354 could not detect a working armasm64 on this setup and silently skipped their assembly path. Loader 1.4.355 fixed the assembler detection, which unmasked the issue. See [5aee62](https://github.com/KhronosGroup/Vulkan-Loader/commit/5aee62b4bba7415b83e01ad78b6196fedb282acf).
  - Use the runner `windows-11-arm` to build natively instead of cross-compiling.

## Type of change

bug fix

## Tests

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.3 (git-6984e91b5f) / Ubuntu 24.04.4 LTS

Total Tests:    86
Passed:         71
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         4 (in skip list)
Success Rate: 100.0%

### AMD Radeon RX 6600 / AMD proprietary driver 26.7.1 (AMD proprietary shader compiler) / Windows 10

Total Tests:    86
Passed:         37
Crashed:         3
Failed:          2
Not Supported:  40
Skipped:         4 (in skip list)
Success Rate: 88.1%