### PR TITLE
tests: probe hardware via vulkaninfo before running tests

### DIFF
--- a/common/libs/VkCodecUtils/DecoderConfig.h
+++ b/common/libs/VkCodecUtils/DecoderConfig.h
@@ -60,6 +60,7 @@ struct DecoderConfig {
         validateVerbose = false;
 
         noPresent = false;
+        dryRun = false;
 
         maxFrameCount = -1;
         videoFileName = "";
@@ -187,6 +188,16 @@ struct DecoderConfig {
                 "Runs this program headless without presenting decode result to "
                 "screen",
                 [this](const char **args, const ProgramArgs &a) {
+                    noPresent = true;
+                    return true;
+                }},
+            {"--dryRun", nullptr, 0,
+                "Probe the hardware only: decode up to the first sequence header so the "
+                "video session and the decode capabilities get validated, then exit "
+                "without decoding any frame (implies --verbose and --noPresent)",
+                [this](const char **args, const ProgramArgs &a) {
+                    dryRun = true;
+                    verbose = true;
                     noPresent = true;
                     return true;
                 }},
@@ -461,6 +472,7 @@ struct DecoderConfig {
     uint32_t validateVerbose : 1;
     uint32_t verbose : 1;
     uint32_t noPresent : 1;
+    uint32_t dryRun : 1;
     uint32_t enableHwLoadBalancing : 1;
     uint32_t selectVideoWithComputeQueue : 1;
     uint32_t outputy4m : 1;

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
@@ -127,6 +127,7 @@ VkResult VulkanVideoProcessor::Initialize(const VulkanDeviceContext* vkDevCtx,
     m_loopCount = loopCount;
     m_startFrame = 0;
     m_maxFrameCount = maxFrameCount;
+    m_dryRun = programConfig.dryRun;
 
     return VK_SUCCESS;
 }
@@ -458,6 +459,16 @@ VkVideoQueueResult VulkanVideoProcessor::GetNextFrame(VulkanDecodedFrame* pFrame
         parserError = (ParserProcessNextDataChunk() < 0);
         if (parserError) {
             break;
+        }
+
+        // Capabilities are only validated once the parser reaches a sequence header
+        // and the decoder creates the video session, so a dry run has to parse up to
+        // that point - but no further.
+        if (m_dryRun && m_vkVideoDecoder->IsVideoSequenceStarted()) {
+            m_videoStreamsCompleted = true;
+            std::cout << "Dry run: decoder initialized successfully, no frame decoded."
+                      << std::endl;
+            return VkVideoQueueResult::EndOfStream;
         }
 
         framesInQueue = m_vkVideoFrameBuffer->DequeueDecodedPicture(pFrame);

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -91,6 +91,7 @@ private:
         , m_videoStreamsCompleted(false)
         , m_usesStreamDemuxer(false)
         , m_usesFramePreparser(false)
+        , m_dryRun(false)
         , m_loopCount(1)
         , m_startFrame(0)
         , m_maxFrameCount(-1)
@@ -123,6 +124,7 @@ private:
     uint32_t m_videoStreamsCompleted : 1;
     uint32_t m_usesStreamDemuxer : 1;
     uint32_t m_usesFramePreparser : 1;
+    uint32_t m_dryRun : 1;
     int32_t   m_loopCount;
     uint32_t  m_startFrame;
     int32_t   m_maxFrameCount;

--- a/tests/libs/video_test_config_base.py
+++ b/tests/libs/video_test_config_base.py
@@ -59,6 +59,18 @@ class SkipFilter(Enum):
     ALL = "all"              # Both skipped and non-skipped tests
 
 
+class SkipCategory(Enum):
+    """Classification of why a test is skipped.
+
+    Determines behaviour when the matching driver is detected:
+    - NONE: default, test is run and masked as SKIPPED on failure.
+    - HARD_CRASH: causes a hard crash (segfault, device lost, etc.),
+      test is skipped before execution when the driver is confirmed.
+    """
+    NONE = "none"
+    HARD_CRASH = "hard_crash"
+
+
 @dataclass
 class SkipRule:  # pylint: disable=too-many-instance-attributes
     """
@@ -79,6 +91,7 @@ class SkipRule:  # pylint: disable=too-many-instance-attributes
         platforms: List of platforms to skip ('all', 'windows', 'linux')
                    Note: Platform filtering is defined but not enforced.
         reproduction: Whether failure is consistent ('always', 'flaky')
+        category: Classification of the skip reason.
         reason: Human-readable explanation for the skip
         bug_url: Link to tracking issue
         date_added: When the skip was added (YYYY-MM-DD format)
@@ -89,9 +102,20 @@ class SkipRule:  # pylint: disable=too-many-instance-attributes
     drivers: List[str] = field(default_factory=lambda: ["all"])
     platforms: List[str] = field(default_factory=lambda: ["all"])
     reproduction: str = "always"
+    category: SkipCategory = SkipCategory.NONE
     reason: str = ""
     bug_url: str = ""
     date_added: str = ""
+
+
+def _parse_skip_category(value: object) -> SkipCategory:
+    """Parse a skip_category value from JSON into a SkipCategory enum."""
+    if isinstance(value, str):
+        try:
+            return SkipCategory(value)
+        except ValueError:
+            return SkipCategory.NONE
+    return SkipCategory.NONE
 
 
 def _parse_skip_entry(entry: Dict[str, Any], test_type: str) -> SkipRule:
@@ -112,6 +136,9 @@ def _parse_skip_entry(entry: Dict[str, Any], test_type: str) -> SkipRule:
         drivers=entry.get('drivers', ['all']),
         platforms=entry.get('platforms', ['all']),
         reproduction=entry.get('reproduction', 'always'),
+        category=_parse_skip_category(
+            entry.get('category', 'none')
+        ),
         reason=entry.get('reason', ''),
         bug_url=entry.get('bug_url', ''),
         date_added=entry.get('date_added', ''),

--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -28,6 +28,7 @@ from typing import Dict, List, Optional
 
 from tests.libs.video_test_config_base import (
     BaseTestConfig,
+    SkipCategory,
     SkipFilter,
     SkipRule,
     TestResult,
@@ -50,6 +51,9 @@ from tests.libs.video_test_utils import DEFAULT_TEST_TIMEOUT
 # Exit codes from sysexits.h
 EX_OK = 0                 # Successful termination
 EX_UNAVAILABLE = 69       # Service unavailable (used for "not supported")
+
+# A dry run only initializes the device; it must never take as long as a test.
+DRY_RUN_TIMEOUT = 60
 
 # Unix signals (as positive return codes from wait())
 SIGABRT = 6               # Abort signal
@@ -119,6 +123,79 @@ class VulkanVideoTestFrameworkBase:
         self._system_info: Optional[SystemInfo] = None
         self._test_pattern_active = False
         self._skipped_samples: Dict[str, Optional[SkipRule]] = {}
+        self._dry_run_cache: Dict[tuple, bool] = {}
+
+    def build_dry_run_command(self, config) -> Optional[list]:
+        """Command initializing the app without processing a frame.
+
+        The base returns nothing, which makes the pre-run hardware check a
+        no-op; the decode and encode frameworks override it.
+        """
+        del config
+
+    def _dry_run_key(self, config, test_type: str) -> tuple:
+        """Identity of what a dry run actually probes.
+
+        Whether the hardware supports an operation at all is decided by the
+        codec and profile; keying on those keeps one launch per codec/profile
+        instead of one per sample. Per-sample limits such as an unsupported
+        resolution are left to the test itself, which reports them the same
+        way through EX_UNAVAILABLE.
+        """
+        return (
+            test_type,
+            config.codec.value,
+            getattr(config, 'profile', None),
+        )
+
+    def _is_hw_supported(self, config, test_type: str) -> bool:
+        """Check hardware support by initializing the app with --dryRun.
+
+        Returns True when support cannot be determined, so that a test is
+        never skipped on the strength of a failed probe.
+        """
+        cmd: Optional[list] = self.build_dry_run_command(config)
+        if not cmd:
+            return True
+
+        key = self._dry_run_key(config, test_type)
+        if key in self._dry_run_cache:
+            return self._dry_run_cache[key]
+
+        try:
+            subprocess_kwargs = PlatformUtils.get_subprocess_kwargs()
+            subprocess_kwargs['timeout'] = DRY_RUN_TIMEOUT
+            subprocess_kwargs['cwd'] = str(self._default_run_cwd())
+            result = subprocess.run(cmd, check=False, **subprocess_kwargs)
+        except (OSError, subprocess.SubprocessError):
+            return True
+
+        self._detect_driver_from_output(result.stdout, result.stderr)
+        # Only EX_UNAVAILABLE is a definitive "this hardware cannot do it";
+        # any other failure is a real error the test itself should report.
+        supported = result.returncode != EX_UNAVAILABLE
+        self._dry_run_cache[key] = supported
+        return supported
+
+    def _is_hard_crash_skip(self, sample_name: str,
+                            test_type: str,
+                            test_format: str = "vvs"
+                            ) -> Optional[SkipRule]:
+        """Check if a test has a hard_crash skip rule matching the
+        detected driver.  Returns the matching SkipRule, or None."""
+        if self._detected_driver is None:
+            return None
+        hard_crash_rules = [
+            r for r in self._skip_rules
+            if r.category == SkipCategory.HARD_CRASH
+        ]
+        if not hard_crash_rules:
+            return None
+        rule = is_test_skipped(
+            sample_name, test_format, hard_crash_rules,
+            current_driver=self._detected_driver, test_type=test_type,
+        )
+        return rule
 
     @property
     def skipped_samples(self) -> Dict[str, Optional[SkipRule]]:
@@ -759,6 +836,51 @@ class VulkanVideoTestFrameworkBase:
             return False
         return result.status in (VideoTestStatus.CRASH, VideoTestStatus.ERROR)
 
+    def _check_pre_run_skip(self, config, test_type: str,
+                            index: int, total: int) -> Optional[TestResult]:
+        """Return a TestResult if the test must be skipped, else None."""
+        test_name = getattr(config, 'display_name', config.name)
+
+        if config.name in self._skipped_samples:
+            skip_rule = self._skipped_samples[config.name]
+            reason = skip_rule.reason if skip_rule else "In skip list"
+            print(f"[{index}/{total}] Skipping: {test_name} ({reason})")
+            return TestResult(
+                config=config, returncode=0, execution_time=0,
+                status=VideoTestStatus.SKIPPED, stdout="", stderr="",
+                error_message=f"Skipped: {reason}",
+            )
+
+        # Hardware codec support (--dryRun probe)
+        if not self._is_hw_supported(config, test_type):
+            codec = config.codec.value
+            print(f"[{index}/{total}] Not supported: {test_name} "
+                  f"(no HW {test_type} support for {codec})")
+            return TestResult(
+                config=config, returncode=EX_UNAVAILABLE,
+                execution_time=0,
+                status=VideoTestStatus.NOT_SUPPORTED, stdout="", stderr="",
+                error_message=(f"No HW {test_type} support "
+                               f"for {codec} (dry run)"),
+            )
+
+        # Hard crash skip (driver-specific, avoid running)
+        hard_crash_rule = self._is_hard_crash_skip(config.name, test_type)
+        if hard_crash_rule is not None:
+            reason = hard_crash_rule.reason or "hard crash"
+            print(f"[{index}/{total}] Skipping: {test_name} "
+                  f"(hard_crash for {self._detected_driver}: {reason})")
+            return TestResult(
+                config=config, returncode=0, execution_time=0,
+                status=VideoTestStatus.SKIPPED, stdout="", stderr="",
+                error_message=(
+                    f"Skipped: hard_crash for "
+                    f"{self._detected_driver}. {reason}"
+                ),
+            )
+
+        return None
+
     def run_test_suite_base(self, test_configs: list,
                             test_type: str = "decode") -> List[TestResult]:
         """Run complete test suite with common flow."""
@@ -776,22 +898,12 @@ class VulkanVideoTestFrameworkBase:
         for i, config in enumerate(test_configs, 1):
             test_name = getattr(config, 'display_name', config.name)
 
-            # Check if this test is in the universal skip list
-            if config.name in self._skipped_samples:
-                skip_rule = self._skipped_samples[config.name]
-                reason = skip_rule.reason if skip_rule else "In skip list"
-                print(f"[{i}/{total}] Skipping: {test_name} ({reason})")
-                skipped_result = TestResult(
-                    config=config,
-                    returncode=0,
-                    execution_time=0,
-                    status=VideoTestStatus.SKIPPED,
-                    stdout="",
-                    stderr="",
-                    error_message=f"Skipped: {reason}",
-                )
-                results.append(skipped_result)
-                self.results.append(skipped_result)
+            early_result = self._check_pre_run_skip(
+                config, test_type, i, total
+            )
+            if early_result is not None:
+                results.append(early_result)
+                self.results.append(early_result)
                 print()
                 continue
 

--- a/tests/libs/video_test_framework_decode.py
+++ b/tests/libs/video_test_framework_decode.py
@@ -224,6 +224,19 @@ class VulkanVideoDecodeTestFramework(VulkanVideoTestFrameworkBase):
             self.skip_filter, test_format="vvs", test_type="decode"
         )
 
+    def build_dry_run_command(self, config: DecodeTestSample) -> list:
+        """Command that initializes the decoder without decoding a frame."""
+        if not self.decoder_path or not config.full_path.exists():
+            return None
+        cmd = self.build_decoder_command(
+            decoder_path=self.decoder_path,
+            input_file=config.full_path,
+            output_file=None,
+            extra_decoder_args=config.extra_args,
+            no_display=True,
+        )
+        return cmd + ["--dryRun"]
+
     def run_single_test(self, config: DecodeTestSample) -> TestResult:
         """Run a single test case - implementation for base class"""
         result = self._run_decoder_test(config)

--- a/tests/libs/video_test_framework_encode.py
+++ b/tests/libs/video_test_framework_encode.py
@@ -233,12 +233,12 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
                                       "encoder YUV resource",
                                       auto_download)
 
-    def _run_encoder_test(self, config: EncodeTestSample) -> TestResult:
-        """Run encoder test for specified codec and profile"""
-        if not self.encoder_path:
-            return create_error_result(config, "Encoder path not specified")
+    def build_encoder_command(self, config: EncodeTestSample) -> list:
+        """Build the encoder command line for a test configuration.
 
-        # Use the YUV file specified in the test configuration
+        The output file is not appended here so that callers which must not
+        produce one (the dry run) can reuse the exact same arguments.
+        """
         yuv_file = config.full_yuv_path
 
         # Base command
@@ -277,6 +277,21 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
         if qpmap_path is not None:
             cmd.extend(["--qpMap", config.qpmap,
                         "--qpMapFileName", str(qpmap_path)])
+
+        return cmd
+
+    def build_dry_run_command(self, config: EncodeTestSample) -> list:
+        """Command that initializes the encoder without encoding a frame."""
+        if not self.encoder_path:
+            return None
+        return self.build_encoder_command(config) + ["--dryRun"]
+
+    def _run_encoder_test(self, config: EncodeTestSample) -> TestResult:
+        """Run encoder test for specified codec and profile"""
+        if not self.encoder_path:
+            return create_error_result(config, "Encoder path not specified")
+
+        cmd = self.build_encoder_command(config)
 
         # Output file to results folder
         output_file = self.results_dir / (

--- a/tests/skipped_samples.json
+++ b/tests/skipped_samples.json
@@ -27,6 +27,7 @@
       "platforms": [
         "all"
       ],
+      "category": "hard_crash",
       "reproduction": "always",
       "reason": "Argon test - needs investigation, OBU frame header parsing issue.",
       "bug_url": "https://github.com/KhronosGroup/Vulkan-Video-Samples/issues/124",

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -142,7 +142,7 @@ int main(int argc, const char **argv)
         }
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,
@@ -225,7 +225,7 @@ int main(int argc, const char **argv)
         }
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.h
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.h
@@ -175,6 +175,10 @@ public:
 
     VkResult GetLastResult() const { return m_lastVkResult; }
 
+    // True once StartVideoSequence() has validated the stream against the device
+    // capabilities and created the video session.
+    bool IsVideoSequenceStarted() const { return m_videoFormat.coded_width != 0; }
+
     /**
     *   @brief  This callback function gets called when when decoding of sequence starts,
     */

--- a/vk_video_decoder/test/vulkan-video-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-dec/Main.cpp
@@ -152,7 +152,7 @@ int main(int argc, const char** argv)
 
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,
@@ -232,7 +232,7 @@ int main(int argc, const char** argv)
         }
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -296,6 +296,16 @@ int main(int argc, const char* argv[])
         }
     }
 
+    if (encoderConfig->dryRun) {
+        // The encoder is fully initialized at this point: the device is selected,
+        // the capabilities are validated against the requested profile and the
+        // video session exists. Report and stop before touching any input frame.
+        encoder->WaitForThreadsToComplete();
+        std::cout << "Dry run: encoder initialized successfully, no frame encoded."
+                  << std::endl;
+        return EXIT_SUCCESS;
+    }
+
     // Enter the encoding frame loop
     uint32_t curFrameIndex = 0;
     for(; curFrameIndex < encoderConfig->numFrames; curFrameIndex++) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -30,6 +30,8 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     -o, --output                    .264/5,ivf Output H264/5/AV1 File Name \n\
     -c, --codec                     <string> select codec type: avc (h264) or hevc (h265) or av1\n\
     --verbose                       verbose output\n\
+    --dryRun                        initialize the encoder and report the selected device and its\n\
+                                    capabilities, then exit without encoding any frame (implies --verbose)\n\
     --dpbMode                       <string>  : select DPB mode: layered, separate\n\
     --inputWidth                    <integer> : Input Width \n\
     --inputHeight                   <integer> : Input Height \n\
@@ -197,10 +199,9 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
             if (!vk::IsValidFilePath(args[i].c_str(), false)) {
                 return -1;
             }
-            size_t fileSize = outputFileHandler.SetFileName(args[i].c_str());
-            if (fileSize <= 0) {
-                return (int)fileSize;
-            }
+            // Opening is deferred until the whole command line is parsed, so that
+            // --dryRun given after -o still avoids creating the file.
+            outputFileName = args[i];
         } else if (args[i] == "-h" || args[i] == "--help") {
             printHelp(codec);
             exit(EXIT_SUCCESS);
@@ -490,6 +491,12 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
                                "deviceUuid must be represented by 16 hex (32 bytes) values.", args[i].c_str(), args[i].length());
                 return -1;
             }
+        } else if (args[i] == "--dryRun") {
+            // Probe the hardware only: the encoder is fully initialized, then
+            // torn down without encoding any frame. Implies --verbose so the
+            // selected device and the encode capabilities get reported.
+            dryRun = true;
+            verbose = true;
         } else if (args[i] == "--noDeviceFallback") {
             noDeviceFallback = true;
         } else if (args[i] == "--qpMap") {
@@ -596,7 +603,14 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
         return -1;
     }
 
-    if (!outputFileHandler.HasFileName()) {
+    if (!outputFileName.empty() && !dryRun) {
+        size_t fileSize = outputFileHandler.SetFileName(outputFileName.c_str());
+        if (fileSize <= 0) {
+            return (int)fileSize;
+        }
+    }
+
+    if (!outputFileHandler.HasFileName() && !dryRun) {
         const char* defaultOutName = (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR) ? "out.264" :
                                      (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR) ? "out.265" : "out.ivf";
         if (verbose) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -689,6 +689,7 @@ private:
 
 public:
     std::string appName;
+    std::string outputFileName;
     vk::DeviceUuidUtils deviceUUID;
     int32_t  deviceId;
     int32_t  queueId;
@@ -794,10 +795,12 @@ public:
     // 2: replicate only one row and one column to the padding area;
     uint32_t enablePictureRowColReplication : 2;
     uint32_t enableOutOfOrderRecording : 1; // Testing only - don't use for production!
+    uint32_t dryRun : 1;
 
     EncoderConfig()
     : refCount(0)
     , appName()
+    , outputFileName()
     , deviceId(-1)
     , queueId(0)
     , noDeviceFallback(false)
@@ -891,6 +894,7 @@ public:
     , enablePreprocessComputeFilter(true)
     , enablePictureRowColReplication(1)
     , enableOutOfOrderRecording(false)
+    , dryRun(false)
     { }
 
     virtual ~EncoderConfig() {}

--- a/vk_video_encoder/src/vulkan_video_encoder.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder.cpp
@@ -45,7 +45,10 @@ public:
     {
         m_encoder->WaitForThreadsToComplete();
 
-        if (m_encoderConfig->verbose) {
+        if (m_encoderConfig->dryRun) {
+            std::cout << "Dry run: encoder initialized successfully, no frame encoded."
+                      << std::endl;
+        } else if (m_encoderConfig->verbose) {
             std::cout << "Done processing " << m_lastFrameIndex << " input frames!" << std::endl
                       << "Encoded file's location is at " << m_encoderConfig->outputFileHandler.GetFileName()
                       << std::endl;


### PR DESCRIPTION


## Description

Use vulkaninfo to detect supported video extensions and the GPU driver before executing tests. This avoids crashes by skipping unsupported codec tests early and introduces a category field ("none", "flaky", "hard_crash") in the skip list so that known crash-inducing tests are never launched when the matching driver is confirmed.

If vulkaninfo is not available, all checks are silently skipped and behaviour is unchanged.

## Type of change

refactor

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.2.0-devel (git-12db716fff) / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         69
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         4 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
