### PR TITLE
tests: do not fail encode tests the decoder cannot validate

### DIFF
--- a/tests/libs/video_test_config_base.py
+++ b/tests/libs/video_test_config_base.py
@@ -290,6 +290,7 @@ class TestResult:
             "stdout": kwargs.get("stdout", ""),
             "stderr": kwargs.get("stderr", ""),
             "warning_found": bool(kwargs.get("warning_found", False)),
+            "warning_message": kwargs.get("warning_message", ""),
             "error_message": kwargs.get("error_message", ""),
             "command_line": kwargs.get("command_line", ""),
         }
@@ -329,6 +330,18 @@ class TestResult:
     def warning_found(self, value: bool) -> None:
         """Set the warning flag for this result."""
         self.meta["warning_found"] = bool(value)
+
+    @property
+    def warning_message(self) -> str:
+        """Optional warning message about a non-fatal issue."""
+        return self.meta.get("warning_message", "")
+
+    @warning_message.setter
+    def warning_message(self, value: str) -> None:
+        """Set the warning message and flag for this result."""
+        self.meta["warning_message"] = value
+        if value:
+            self.meta["warning_found"] = True
 
     @property
     def error_message(self) -> str:

--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -396,17 +396,34 @@ class VulkanVideoTestFrameworkBase:
         print(f"### {self.system_info.get_header()}")
         print()
 
+        not_validated = [r for r in results
+                         if r.status == VideoTestStatus.SUCCESS
+                         and r.warning_message]
+
         # Skipped tests are now included in results, so just use len(results)
         print(f"Total Tests:   {len(results):3}")
-        print(f"Passed:        {passed:3}")
+        passed_line = f"Passed:        {passed:3}"
+        if not_validated:
+            passed_line += f" ({len(not_validated)} warning(s))"
+        print(passed_line)
         print(f"Crashed:       {crashed:3}")
         print(f"Failed:        {failed:3}")
         print(f"Not Supported: {not_supported:3}")
         if skipped_hw > 0:
             print(f"Skipped:       {skipped_hw:3} (in skip list)")
+
         effective_total = len(results) - not_supported - skipped_hw
         if effective_total > 0:
             print(f"Success Rate: {passed/effective_total*100:.1f}%")
+
+        if not_validated:
+            print()
+            print("⚠️  The encoded output of the following tests could not be "
+                  "validated:")
+            for result in not_validated:
+                name = getattr(result.config, 'display_name',
+                               result.config.name)
+                print(f"   - {name}")
 
         return print_final_summary(
             (passed, not_supported, crashed, failed), test_type
@@ -435,6 +452,7 @@ class VulkanVideoTestFrameworkBase:
                 result.execution_time * 1000, 2
             ),
             "warning_found": result.warning_found,
+            "warning_message": result.warning_message,
             "error_message": result.error_message,
             "command_line": result.command_line
         }
@@ -632,10 +650,12 @@ class VulkanVideoTestFrameworkBase:
         extra_decoder_args: list = None,
         config: BaseTestConfig = None,
     ) -> tuple:
-        """Validate encoded file with decoder. Returns (success, output)."""
+        """Validate encoded file with decoder.
+        Returns (success, output, status)."""
+
         if not decoder_path or not decoder_path.exists():
             print("  ⚠️  Decoder path not valid for validation")
-            return False, "Decoder path not valid"
+            return False, "Decoder path not valid", VideoTestStatus.ERROR
 
         print(f"  🔍 Validating with decoder: {input_file.name}")
 
@@ -665,9 +685,13 @@ class VulkanVideoTestFrameworkBase:
 
         if result.status == VideoTestStatus.SUCCESS:
             print("  ✓ Decoder validation passed")
-            return True, None
+            return True, None, result.status
 
-        print("  ✗ Decoder validation failed")
+        if result.status != VideoTestStatus.NOT_SUPPORTED:
+            # The NOT_SUPPORTED case is reported by the caller alongside the
+            # test result, so avoid printing a duplicate warning here.
+            print("  ✗ Decoder validation failed")
+
         output_lines = [
             f"status: {result.status.name}, exit code: {result.returncode}"]
         if result.stdout:
@@ -677,7 +701,7 @@ class VulkanVideoTestFrameworkBase:
             for line in result.stderr.strip().split('\n')[-10:]:
                 output_lines.append(line)
 
-        return False, '\n'.join(output_lines)
+        return False, '\n'.join(output_lines), result.status
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     # pylint: disable=too-many-locals
@@ -902,8 +926,12 @@ class VulkanVideoTestFrameworkBase:
         elif self.verbose and (result.stdout or result.stderr):
             print_command_output(result)
 
+        if result.warning_message:
+            print(f"   ⚠️  {result.warning_message}")
+
         decoder_output = result.meta.get("decoder_validation_output")
-        if decoder_output and result.status == VideoTestStatus.ERROR:
+        if decoder_output and (result.status == VideoTestStatus.ERROR or
+                               result.warning_message):
             print("   --- Decoder validation output (last 10 lines) ---")
             for line in decoder_output.split('\n'):
                 print(f"   | {line}")

--- a/tests/libs/video_test_framework_encode.py
+++ b/tests/libs/video_test_framework_encode.py
@@ -300,13 +300,19 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
         if (self.validate_with_decoder and
                 output_file.exists() and
                 result.status == VideoTestStatus.SUCCESS):
-            validation_success, validation_output = (
+            validation_success, validation_output, validation_status = (
                 self._validate_with_decoder(output_file, config)
             )
             if not validation_success:
-                # Decoder validation failed - mark encoder test as error
-                result.status = VideoTestStatus.ERROR
-                result.error_message = "Decoder validation failed"
+                if validation_status == VideoTestStatus.NOT_SUPPORTED:
+                    result.warning_message = (
+                        "Decoder does not support this configuration, "
+                        "encoded output was not validated"
+                    )
+                else:
+                    # Decoder validation failed - mark encoder test as error
+                    result.status = VideoTestStatus.ERROR
+                    result.error_message = "Decoder validation failed"
                 # Store validation output for display after test result
                 result.meta["decoder_validation_output"] = validation_output
 
@@ -348,7 +354,8 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
             config: Encoder test configuration
 
         Returns:
-            Tuple of (success: bool, validation_output: str or None)
+            Tuple of (success: bool, validation_output: str or None,
+                      status: VideoTestStatus)
         """
         # Use base class method to run decoder validation
         return self.run_decoder_validation(

--- a/tests/vvs_test_runner.py
+++ b/tests/vvs_test_runner.py
@@ -433,9 +433,17 @@ class VulkanVideoTestFramework:  # pylint: disable=too-many-instance-attributes
             print(f"### {system_info.get_header()}")
             print()
 
+        # Passed tests that could not have their output validated
+        total_warnings = sum(1 for r in self.all_results
+                             if r.status == VideoTestStatus.SUCCESS
+                             and r.warning_message)
+
         # Skipped tests are now included in all_results
         print(f"Total Tests:   {total_tests:3}")
-        print(f"Passed:        {total_passed:3}")
+        passed_line = f"Passed:        {total_passed:3}"
+        if total_warnings > 0:
+            passed_line += f" ({total_warnings} warning(s))"
+        print(passed_line)
         print(f"Crashed:       {total_crashed:3}")
         print(f"Failed:        {total_failed:3}")
         print(f"Not Supported: {total_not_supported:3}")


### PR DESCRIPTION
## Description

Decoder validation is executed after every successful encode and any non-zero decoder exit marked the encode test as failed. That mixes two different scenarios: an encoded file that is actually broken, and a decoder that has no support for the encoded configuration.

Print a warning in case the decoder does not have the capabilities to validate the encoded file and mark the encode test as successful. The decoder reports this before decoding anything, so there is no information about the validity of the encoded file.

See #231 for details and how to reproduce.

## Type of change

bug fix

## Issue (optional)

Fixes part of #231 .

## Tests

### NVIDIA GeForce RTX 4060 Ti / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    83
Passed:         72
Crashed:         0
Failed:          0
Not Supported:  10
Skipped:         1 (in skip list)
Success Rate: 100.0%
