### PR TITLE
release: create v0.5.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,17 @@
+v0.5.0:
+  - Encoder: add VK_KHR_video_encode_feedback2 support for AV1
+    (--pictureFeedback, --pixelCountFeedback, --skippedPixelCountFeedback,
+    --enablePerPartitionFeedback, --maxPerPartitionFeedbackEntries)
+  - Build: Vulkan SDK minimum raised to 1.4.358 (required by
+    VK_KHR_video_encode_feedback2)
+  - Encoder: default msbShift for >8-bit input so high bit-depth samples
+    are no longer encoded LSB-aligned
+  - Encoder: set the AV1 transfer mode properly and stop forcing a default
+    AV1 rateControlMode
+  - Common: validate queue existence in VulkanDeviceContext to avoid an
+    assert when no encode queue is available
+  - Docs: add AI-Assisted Contributions and CLA pre-disclosure to CONTRIBUTING
+
 v0.4.4:
   - Encoder: enable shaderc compute filter for static build allowing CTS
     to encode AV1 properly

--- a/common/include/VkVSCommon.h
+++ b/common/include/VkVSCommon.h
@@ -9,8 +9,8 @@ extern "C" {
 
 // Version information
 #define VKVS_VERSION_MAJOR 0
-#define VKVS_VERSION_MINOR 4
-#define VKVS_VERSION_PATCH 4
+#define VKVS_VERSION_MINOR 5
+#define VKVS_VERSION_PATCH 0
 
 // Helper macros for version string construction (prefixed to avoid reserved identifier issues)
 #define VKVS_STRINGIFY(x) #x

--- a/tests/skipped_samples.json
+++ b/tests/skipped_samples.json
@@ -7,7 +7,8 @@
       "source_filepath": "video/av1/av1-argon_test1019.obu",
       "format": "vvs",
       "drivers": [
-        "radv"
+        "radv",
+        "amd"
       ],
       "platforms": [
         "all"
@@ -22,7 +23,8 @@
       "source_filepath": "video/av1/av1-argon_test787.obu",
       "format": "vvs",
       "drivers": [
-        "radv"
+        "radv",
+        "amd"
       ],
       "platforms": [
         "all"
@@ -38,7 +40,9 @@
       "format": "vvs",
       "drivers": [
         "radv",
-        "anv"
+        "anv",
+        "amd",
+        "intel"
       ],
       "platforms": [
         "all"
@@ -120,6 +124,20 @@
       "bug_url": "https://github.com/KhronosGroup/Vulkan-Video-Samples/issues/149",
       "date_added": "2026-01-22",
       "source_filepath": "resources/video/av1/av1-176x144-main-globalmotion-8.ivf"
+    },
+    {
+      "name": "av1_svc_l1t2_8bit",
+      "format": "vvs",
+      "drivers": [
+        "amd"
+      ],
+      "platforms": [
+        "windows"
+      ],
+      "reproduction": "always",
+      "reason": "MD5 mismatch",
+      "bug_url": "https://github.com/KhronosGroup/Vulkan-Video-Samples/issues/234",
+      "date_added": "2026-08-20"
     }
   ],
   "encode": [


### PR DESCRIPTION
## Description

v0.5.0:
  - Encoder: add VK_KHR_video_encode_feedback2 support for AV1
    (--pictureFeedback, --pixelCountFeedback, --skippedPixelCountFeedback,
    --enablePerPartitionFeedback, --maxPerPartitionFeedbackEntries)
  - Build: Vulkan SDK minimum raised to 1.4.358 (required by
    VK_KHR_video_encode_feedback2)
  - Encoder: default msbShift for >8-bit input so high bit-depth samples
    are no longer encoded LSB-aligned
  - Encoder: set the AV1 transfer mode properly and stop forcing a default
    AV1 rateControlMode
  - Common: validate queue existence in VulkanDeviceContext to avoid an
    assert when no encode queue is available
  - Docs: add AI-Assisted Contributions and CLA pre-disclosure to CONTRIBUTING

## Type of change

release

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### Intel(R) Iris(R) Xe Graphics (ADL GT2) / Intel open-source Mesa driver Mesa 26.2.0-devel (git-95e47c6072) / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         57
Crashed:         0
Failed:          0
Not Supported:  25
Skipped:         3 (in skip list)
Success Rate: 100.0%

### NVIDIA GeForce RTX 4060 Ti / NVIDIA 595.44.00 / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         73
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         1 (in skip list)
Success Rate: 100.0%

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.3.0-devel (git-c6bc6d38c0) / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         70
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         4 (in skip list)
Success Rate: 100.0%

### NVIDIA GeForce RTX 4060 / NVIDIA 595.81 / Windows 11

Total Tests:    85
Passed:         73
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         1 (in skip list)
Success Rate: 100.0%

### Intel(R) UHD Graphics 770 UHD Graphics 770 / Intel Corporation 101.7088 / Windows 11

Total Tests:    85
Passed:         28
Crashed:         0
Failed:          0
Not Supported:  54
Skipped:         3 (in skip list)
Success Rate: 100.0%

### AMD Radeon RX 7600 / AMD proprietary driver 26.7.1 (LLPC) / Windows 11

Total Tests:    85
Passed:         68
Crashed:         0
Failed:          0
Not Supported:  12
Skipped:         5 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
