### PR TITLE
VkVideoEncoder: Ensure m_encoder is valid before dereferencing it on Deinitialize()

### DIFF
--- a/vk_video_encoder/src/vulkan_video_encoder.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder.cpp
@@ -43,9 +43,11 @@ public:
 
     void Deinitialize()
     {
-        m_encoder->WaitForThreadsToComplete();
+        if (m_encoder) {
+            m_encoder->WaitForThreadsToComplete();
+        }
 
-        if (m_encoderConfig->verbose) {
+        if (m_encoderConfig && m_encoderConfig->verbose) {
             std::cout << "Done processing " << m_lastFrameIndex << " input frames!" << std::endl
                       << "Encoded file's location is at " << m_encoderConfig->outputFileHandler.GetFileName()
                       << std::endl;


### PR DESCRIPTION
## Description

If the Vulkan video encoder implementation failed to initialize for some reason, like out-of-memory error, the VulkanVideoEncoderImpl object may be only partly initialized when Deinitialize() is called.

To avoid a crash, ensure m_encoder is not-nullptr before calling m_encoder->WaitForThreadsToComplete().

## Type of change

Bug fix.

## Tests

### NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition / NVIDIA 630.01 / Windows 11

Total Tests:    85
Passed:         72
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         2 (in skip list)
Success Rate: 100.0%

### vulkan-cts-1.4.6.2

Repro comes from running [vulkan-cts-1.4.6.2](https://github.com/KhronosGroup/VK-GL-CTS/releases/tag/vulkan-cts-1.4.6.2) on a 32-bit platform with the following tests:
```
dEQP-VK.video.encode.av1.7680x4320_10le_420.i_p_b3_13_15.default
dEQP-VK.video.encode.av1.7680x4320_10le_420.i_p_b3_13_15.layered_dpb
dEQP-VK.video.encode.av1.7680x4320_10le_420.i_p_b3_13_15.tiling_4x4
dEQP-VK.video.encode.av1.7680x4320_10le_420.i_p_b3_13_15.tiling_4x4_layered_dpb
```
