### PR TITLE
tests: handle hard_crash category in skipped_samples.json

### DIFF
--- a/common/libs/VkCodecUtils/DecoderConfig.h
+++ b/common/libs/VkCodecUtils/DecoderConfig.h
@@ -60,6 +60,7 @@ struct DecoderConfig {
         validateVerbose = false;
 
         noPresent = false;
+        dryRun = false;
 
         maxFrameCount = -1;
         videoFileName = "";
@@ -187,6 +188,15 @@ struct DecoderConfig {
                 "Runs this program headless without presenting decode result to "
                 "screen",
                 [this](const char **args, const ProgramArgs &a) {
+                    noPresent = true;
+                    return true;
+                }},
+            {"--dryRun", nullptr, 0,
+                "Probe the hardware only: decode up to the first sequence header so the "
+                "video session and the decode capabilities get validated, then exit "
+                "without decoding any frame (implies --noPresent)",
+                [this](const char **args, const ProgramArgs &a) {
+                    dryRun = true;
                     noPresent = true;
                     return true;
                 }},
@@ -461,6 +471,7 @@ struct DecoderConfig {
     uint32_t validateVerbose : 1;
     uint32_t verbose : 1;
     uint32_t noPresent : 1;
+    uint32_t dryRun : 1;
     uint32_t enableHwLoadBalancing : 1;
     uint32_t selectVideoWithComputeQueue : 1;
     uint32_t outputy4m : 1;

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.cpp
@@ -115,6 +115,7 @@ VkResult VulkanVideoProcessor::Initialize(const VulkanDeviceContext* vkDevCtx,
         return result;
     }
     m_vkVideoDecoder->SetVerbose(programConfig.verbose);
+    m_vkVideoDecoder->SetDryRun(programConfig.dryRun);
     const uint32_t defaultMinBufferSize = 2 * 1024 * 1024; // 2MB
     result = CreateParser(nullptr,
                           m_videoStreamDemuxer->GetVideoCodec(),
@@ -127,6 +128,7 @@ VkResult VulkanVideoProcessor::Initialize(const VulkanDeviceContext* vkDevCtx,
     m_loopCount = loopCount;
     m_startFrame = 0;
     m_maxFrameCount = maxFrameCount;
+    m_dryRun = programConfig.dryRun;
 
     return VK_SUCCESS;
 }
@@ -458,6 +460,16 @@ VkVideoQueueResult VulkanVideoProcessor::GetNextFrame(VulkanDecodedFrame* pFrame
         parserError = (ParserProcessNextDataChunk() < 0);
         if (parserError) {
             break;
+        }
+
+        // Capabilities are only validated once the parser reaches a sequence header
+        // and the decoder creates the video session, so a dry run has to parse up to
+        // that point - but no further.
+        if (m_dryRun && m_vkVideoDecoder->IsVideoSequenceStarted()) {
+            m_videoStreamsCompleted = true;
+            std::cout << "Dry run: decoder initialized successfully, no frame decoded."
+                      << std::endl;
+            return VkVideoQueueResult::EndOfStream;
         }
 
         framesInQueue = m_vkVideoFrameBuffer->DequeueDecodedPicture(pFrame);

--- a/common/libs/VkCodecUtils/VulkanVideoProcessor.h
+++ b/common/libs/VkCodecUtils/VulkanVideoProcessor.h
@@ -91,6 +91,7 @@ private:
         , m_videoStreamsCompleted(false)
         , m_usesStreamDemuxer(false)
         , m_usesFramePreparser(false)
+        , m_dryRun(false)
         , m_loopCount(1)
         , m_startFrame(0)
         , m_maxFrameCount(-1)
@@ -123,6 +124,7 @@ private:
     uint32_t m_videoStreamsCompleted : 1;
     uint32_t m_usesStreamDemuxer : 1;
     uint32_t m_usesFramePreparser : 1;
+    uint32_t m_dryRun : 1;
     int32_t   m_loopCount;
     uint32_t  m_startFrame;
     int32_t   m_maxFrameCount;

--- a/tests/libs/video_test_config_base.py
+++ b/tests/libs/video_test_config_base.py
@@ -19,6 +19,7 @@ limitations under the License.
 """
 
 import json
+import sys
 import zipfile
 import fnmatch
 from dataclasses import dataclass, field
@@ -59,6 +60,18 @@ class SkipFilter(Enum):
     ALL = "all"              # Both skipped and non-skipped tests
 
 
+class SkipCategory(Enum):
+    """Classification of why a test is skipped.
+
+    Determines behaviour when the matching driver is detected:
+    - NONE: default, test is run and masked as SKIPPED on failure.
+    - HARD_CRASH: causes a hard crash (segfault, device lost, etc.),
+      test is skipped before execution when the driver is confirmed.
+    """
+    NONE = "none"
+    HARD_CRASH = "hard_crash"
+
+
 @dataclass
 class SkipRule:  # pylint: disable=too-many-instance-attributes
     """
@@ -85,6 +98,7 @@ class SkipRule:  # pylint: disable=too-many-instance-attributes
         platforms: List of platforms to skip ('all', 'windows', 'linux')
                    Note: Platform filtering is defined but not enforced.
         reproduction: Whether failure is consistent ('always', 'flaky')
+        category: Classification of the skip reason.
         reason: Human-readable explanation for the skip
         bug_url: Link to tracking issue
         date_added: When the skip was added (YYYY-MM-DD format)
@@ -96,9 +110,22 @@ class SkipRule:  # pylint: disable=too-many-instance-attributes
     devices: List[str] = field(default_factory=list)
     platforms: List[str] = field(default_factory=lambda: ["all"])
     reproduction: str = "always"
+    category: SkipCategory = SkipCategory.NONE
     reason: str = ""
     bug_url: str = ""
     date_added: str = ""
+
+
+def _parse_skip_category(value: object) -> SkipCategory:
+    """Parse a skip_category value from JSON into a SkipCategory enum."""
+    if isinstance(value, str):
+        try:
+            return SkipCategory(value)
+        except ValueError:
+            print(f"Warning: unknown skip category '{value}', "
+                  f"treating as '{SkipCategory.NONE.value}'", file=sys.stderr)
+            return SkipCategory.NONE
+    return SkipCategory.NONE
 
 
 def _parse_skip_entry(entry: Dict[str, Any], test_type: str) -> SkipRule:
@@ -120,6 +147,9 @@ def _parse_skip_entry(entry: Dict[str, Any], test_type: str) -> SkipRule:
         devices=entry.get('devices', []),
         platforms=entry.get('platforms', ['all']),
         reproduction=entry.get('reproduction', 'always'),
+        category=_parse_skip_category(
+            entry.get('category', 'none')
+        ),
         reason=entry.get('reason', ''),
         bug_url=entry.get('bug_url', ''),
         date_added=entry.get('date_added', ''),

--- a/tests/libs/video_test_dry_run_probe.py
+++ b/tests/libs/video_test_dry_run_probe.py
@@ -1,0 +1,49 @@
+"""
+Video Test Dry Run Probe
+Hardware capability probing via the applications' --dryRun mode.
+
+Copyright 2026 Igalia S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+from tests.libs.video_test_platform_utils import PlatformUtils
+
+# A dry run only initializes the device; it must never take as long as a test.
+DRY_RUN_TIMEOUT = 60
+
+
+def run_dry_run(cmd: Optional[list], *, unsupported_exit_code: int,
+                cwd: Optional[Path] = None) -> Tuple[bool, str, str]:
+    """Run a dry-run command; report support plus the output it produced.
+
+    The support verdict is True whenever it cannot be determined, so that a
+    test is never skipped on the strength of a probe that failed to run.
+    """
+    if not cmd:
+        return True, "", ""
+
+    try:
+        subprocess_kwargs = PlatformUtils.get_subprocess_kwargs()
+        subprocess_kwargs['timeout'] = DRY_RUN_TIMEOUT
+        if cwd is not None:
+            subprocess_kwargs['cwd'] = str(cwd)
+        result = subprocess.run(cmd, check=False, **subprocess_kwargs)
+    except (OSError, subprocess.SubprocessError):
+        return True, "", ""
+
+    return (result.returncode != unsupported_exit_code), result.stdout, result.stderr

--- a/tests/libs/video_test_framework_base.py
+++ b/tests/libs/video_test_framework_base.py
@@ -28,6 +28,7 @@ from typing import Dict, List, Optional
 
 from tests.libs.video_test_config_base import (
     BaseTestConfig,
+    SkipCategory,
     SkipFilter,
     SkipRule,
     TestResult,
@@ -38,13 +39,15 @@ from tests.libs.video_test_config_base import (
 )
 
 from tests.libs.video_test_platform_utils import PlatformUtils
+from tests.libs.video_test_dry_run_probe import run_dry_run
 from tests.libs.video_test_driver_detect import (
     parse_driver_from_output, parse_system_info_from_output, SystemInfo,
     get_os_info
 )
 from tests.libs.video_test_result_reporter import (
-    get_status_display, print_codec_breakdown, print_detailed_results,
-    print_final_summary, print_command_output)
+    count_results_by_status, get_status_display, group_results_by_codec,
+    print_codec_breakdown, print_detailed_results, print_final_summary,
+    print_command_output, result_to_dict)
 from tests.libs.video_test_utils import DEFAULT_TEST_TIMEOUT
 
 # Exit codes from sysexits.h
@@ -119,6 +122,40 @@ class VulkanVideoTestFrameworkBase:
         self._system_info: Optional[SystemInfo] = None
         self._test_pattern_active = False
         self._skipped_samples: Dict[str, Optional[SkipRule]] = {}
+
+    def build_dry_run_command(self, _config) -> Optional[list]:
+        """Command initializing the app without processing a frame - to be
+        implemented by subclasses
+
+        Returns None when no command can be built, which makes the driver
+        probe a no-op for that test.
+        """
+        return None
+
+    def _detect_driver_once(self, test_configs: list) -> None:
+        """Run one app to learn the GPU driver before the suite starts."""
+        for config in test_configs:
+            if self._detected_driver is not None:
+                return
+            cmd: Optional[list] = self.build_dry_run_command(config)
+            if cmd:
+                _, stdout, stderr = run_dry_run(
+                    cmd, unsupported_exit_code=EX_UNAVAILABLE,
+                    cwd=self._default_run_cwd()
+                )
+                self._detect_driver_from_output(stdout, stderr)
+
+    def _is_hard_crash_skip(self, sample_name: str, test_type: str,
+                            test_format: str = "vvs") -> Optional[SkipRule]:
+        """Hard_crash skip rule matching the detected driver, or None."""
+        if self._detected_driver is None:
+            return None
+        return is_test_skipped(
+            sample_name, test_format,
+            [r for r in self._skip_rules
+             if r.category == SkipCategory.HARD_CRASH],
+            current_driver=self._detected_driver, test_type=test_type,
+        )
 
     @property
     def skipped_samples(self) -> Dict[str, Optional[SkipRule]]:
@@ -317,16 +354,7 @@ class VulkanVideoTestFrameworkBase:
 
     def _count_results_by_status(self, results: List[TestResult]) -> tuple:
         """Count results by status type"""
-        passed = sum(1 for r in results if r.status == VideoTestStatus.SUCCESS)
-        not_supported = sum(
-            1 for r in results if r.status == VideoTestStatus.NOT_SUPPORTED
-        )
-        crashed = sum(1 for r in results if r.status == VideoTestStatus.CRASH)
-        failed = sum(1 for r in results if r.status == VideoTestStatus.ERROR)
-        skipped = sum(
-            1 for r in results if r.status == VideoTestStatus.SKIPPED
-        )
-        return passed, not_supported, crashed, failed, skipped
+        return count_results_by_status(results)
 
     def _count_skipped_tests(self, samples: list, test_format: str = "vvs",
                              test_type: str = "decode") -> int:
@@ -351,27 +379,7 @@ class VulkanVideoTestFrameworkBase:
 
     def _group_results_by_codec(self, results: List[TestResult]) -> dict:
         """Group results by codec with counts"""
-        codec_results = {}
-        for result in results:
-            codec = result.config.codec.value
-            if codec not in codec_results:
-                codec_results[codec] = {
-                    "pass": 0, "not_supported": 0, "crash": 0, "fail": 0,
-                    "skipped": 0, "total": 0
-                }
-
-            codec_results[codec]["total"] += 1
-            if result.status == VideoTestStatus.SUCCESS:
-                codec_results[codec]["pass"] += 1
-            elif result.status == VideoTestStatus.NOT_SUPPORTED:
-                codec_results[codec]["not_supported"] += 1
-            elif result.status == VideoTestStatus.CRASH:
-                codec_results[codec]["crash"] += 1
-            elif result.status == VideoTestStatus.SKIPPED:
-                codec_results[codec]["skipped"] += 1
-            else:
-                codec_results[codec]["fail"] += 1
-        return codec_results
+        return group_results_by_codec(results)
 
     def print_summary(  # pylint: disable=too-many-locals
             self, results: List[TestResult] = None,
@@ -442,35 +450,7 @@ class VulkanVideoTestFrameworkBase:
 
     def result_to_dict(self, result: TestResult, test_type: str) -> dict:
         """Convert a TestResult to a dictionary for JSON export."""
-        test_name = (result.config.display_name
-                     if hasattr(result.config, 'display_name')
-                     else result.config.name)
-        result_dict = {
-            "name": test_name,
-            "codec": result.config.codec.value,
-            "test_type": test_type,
-            "description": result.config.description,
-            "status": result.status.value,
-            "success": result.success,
-            "returncode": result.returncode,
-            "execution_time_ms": round(
-                result.execution_time * 1000, 2
-            ),
-            "warning_found": result.warning_found,
-            "warning_message": result.warning_message,
-            "error_message": result.error_message,
-            "command_line": result.command_line
-        }
-
-        if hasattr(result.config, 'full_path'):
-            result_dict["input_file"] = str(result.config.full_path)
-        elif hasattr(result.config, 'full_yuv_path'):
-            result_dict["input_file"] = str(result.config.full_yuv_path)
-
-        if hasattr(result.config, 'profile') and result.config.profile:
-            result_dict["profile"] = result.config.profile
-
-        return result_dict
+        return result_to_dict(result, test_type)
 
     def export_results_json(self, output_file: str, test_type: str) -> bool:
         """Export test results to JSON file. Returns True on success."""
@@ -625,6 +605,7 @@ class VulkanVideoTestFrameworkBase:
         output_file: Path = None,
         extra_decoder_args: list = None,
         no_display: bool = True,
+        dry_run: bool = False,
     ) -> list:
         """Build decoder command with standard options."""
         cmd = [
@@ -647,6 +628,8 @@ class VulkanVideoTestFrameworkBase:
         cmd.append("--noDeviceFallback")
         if extra_decoder_args:
             cmd.extend(extra_decoder_args)
+        if dry_run:
+            cmd.append("--dryRun")
 
         return cmd
 
@@ -790,6 +773,37 @@ class VulkanVideoTestFrameworkBase:
             return False
         return result.status in (VideoTestStatus.CRASH, VideoTestStatus.ERROR)
 
+    def _check_pre_run_skip(self, config, test_type: str,
+                            index: int, total: int) -> Optional[TestResult]:
+        """Return a TestResult if the test must be skipped, else None."""
+        test_name = getattr(config, 'display_name', config.name)
+
+        def early(tail: str, status: VideoTestStatus, message: str,
+                  returncode: int = 0) -> TestResult:
+            print(f"[{index}/{total}] {tail}")
+            return TestResult(
+                config=config, returncode=returncode, execution_time=0,
+                status=status, stdout="", stderr="", error_message=message,
+            )
+
+        if config.name in self._skipped_samples:
+            skip_rule = self._skipped_samples[config.name]
+            reason = skip_rule.reason if skip_rule else "In skip list"
+            return early(f"Skipping: {test_name} ({reason})",
+                         VideoTestStatus.SKIPPED, f"Skipped: {reason}")
+
+        # Checked before the dry-run probe: the probe launches the very
+        # binary a hard_crash rule exists to keep from running.
+        hard_crash_rule = self._is_hard_crash_skip(config.name, test_type)
+        if hard_crash_rule is not None:
+            reason = hard_crash_rule.reason or "hard crash"
+            driver = self._detected_driver
+            note = f"known to hard crash on {driver}: {reason}"
+            return early(f"Not run: {test_name} ({note})",
+                         VideoTestStatus.SKIPPED, f"Not run, {note}")
+
+        return None
+
     def run_test_suite_base(self, test_configs: list,
                             test_type: str = "decode") -> List[TestResult]:
         """Run complete test suite with common flow."""
@@ -804,25 +818,20 @@ class VulkanVideoTestFrameworkBase:
         results: List[TestResult] = []
         total = len(test_configs)
 
+        # Driver-specific skip rules need the driver, and it is only known
+        # once an app has run. Probe once here so the rules apply from the
+        # first test rather than from the second.
+        self._detect_driver_once(test_configs)
+
         for i, config in enumerate(test_configs, 1):
             test_name = getattr(config, 'display_name', config.name)
 
-            # Check if this test is in the universal skip list
-            if config.name in self._skipped_samples:
-                skip_rule = self._skipped_samples[config.name]
-                reason = skip_rule.reason if skip_rule else "In skip list"
-                print(f"[{i}/{total}] Skipping: {test_name} ({reason})")
-                skipped_result = TestResult(
-                    config=config,
-                    returncode=0,
-                    execution_time=0,
-                    status=VideoTestStatus.SKIPPED,
-                    stdout="",
-                    stderr="",
-                    error_message=f"Skipped: {reason}",
-                )
-                results.append(skipped_result)
-                self.results.append(skipped_result)
+            early_result = self._check_pre_run_skip(
+                config, test_type, i, total
+            )
+            if early_result is not None:
+                results.append(early_result)
+                self.results.append(early_result)
                 print()
                 continue
 

--- a/tests/libs/video_test_framework_decode.py
+++ b/tests/libs/video_test_framework_decode.py
@@ -19,7 +19,7 @@ limitations under the License.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from tests.libs.video_test_fetch_sample import FetchableResource
 from tests.libs.video_test_config_base import (
@@ -222,6 +222,18 @@ class VulkanVideoDecodeTestFramework(VulkanVideoTestFrameworkBase):
         return self.filter_test_suite(
             self.decode_samples,
             self.skip_filter, test_format="vvs", test_type="decode"
+        )
+
+    def build_dry_run_command(self,
+                              config: DecodeTestSample) -> Optional[list]:
+        """Command that initializes the decoder without decoding a frame."""
+        if not self.decoder_path or not config.full_path.exists():
+            return None
+        return self.build_decoder_command(
+            decoder_path=self.decoder_path,
+            input_file=config.full_path,
+            extra_decoder_args=config.extra_args,
+            dry_run=True,
         )
 
     def run_single_test(self, config: DecodeTestSample) -> TestResult:

--- a/tests/libs/video_test_framework_encode.py
+++ b/tests/libs/video_test_framework_encode.py
@@ -233,12 +233,13 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
                                       "encoder YUV resource",
                                       auto_download)
 
-    def _run_encoder_test(self, config: EncodeTestSample) -> TestResult:
-        """Run encoder test for specified codec and profile"""
-        if not self.encoder_path:
-            return create_error_result(config, "Encoder path not specified")
+    def build_encoder_command(self, config: EncodeTestSample,
+                              dry_run: bool = False) -> list:
+        """Build the encoder command line for a test configuration.
 
-        # Use the YUV file specified in the test configuration
+        The output file is not appended here so that a dry run, which must not
+        produce one, can reuse the exact same arguments.
+        """
         yuv_file = config.full_yuv_path
 
         # Base command
@@ -277,6 +278,25 @@ class VulkanVideoEncodeTestFramework(VulkanVideoTestFrameworkBase):
         if qpmap_path is not None:
             cmd.extend(["--qpMap", config.qpmap,
                         "--qpMapFileName", str(qpmap_path)])
+
+        if dry_run:
+            cmd.append("--dryRun")
+
+        return cmd
+
+    def build_dry_run_command(self,
+                              config: EncodeTestSample) -> Optional[list]:
+        """Command that initializes the encoder without encoding a frame."""
+        if not self.encoder_path:
+            return None
+        return self.build_encoder_command(config, dry_run=True)
+
+    def _run_encoder_test(self, config: EncodeTestSample) -> TestResult:
+        """Run encoder test for specified codec and profile"""
+        if not self.encoder_path:
+            return create_error_result(config, "Encoder path not specified")
+
+        cmd = self.build_encoder_command(config)
 
         # Output file to results folder
         output_file = self.results_dir / (

--- a/tests/libs/video_test_result_reporter.py
+++ b/tests/libs/video_test_result_reporter.py
@@ -158,3 +158,75 @@ def print_command_output(result: TestResult, max_lines: int = 0) -> None:
         else:
             for line in lines:
                 print(f"     {line}")
+
+
+def count_results_by_status(results: List[TestResult]) -> tuple:
+    """Count results by status type"""
+    passed = sum(1 for r in results if r.status == VideoTestStatus.SUCCESS)
+    not_supported = sum(
+        1 for r in results if r.status == VideoTestStatus.NOT_SUPPORTED
+    )
+    crashed = sum(1 for r in results if r.status == VideoTestStatus.CRASH)
+    failed = sum(1 for r in results if r.status == VideoTestStatus.ERROR)
+    skipped = sum(
+        1 for r in results if r.status == VideoTestStatus.SKIPPED
+    )
+    return passed, not_supported, crashed, failed, skipped
+
+
+def group_results_by_codec(results: List[TestResult]) -> dict:
+    """Group results by codec with counts"""
+    codec_results = {}
+    for result in results:
+        codec = result.config.codec.value
+        if codec not in codec_results:
+            codec_results[codec] = {
+                "pass": 0, "not_supported": 0, "crash": 0, "fail": 0,
+                "skipped": 0, "total": 0
+            }
+
+        codec_results[codec]["total"] += 1
+        if result.status == VideoTestStatus.SUCCESS:
+            codec_results[codec]["pass"] += 1
+        elif result.status == VideoTestStatus.NOT_SUPPORTED:
+            codec_results[codec]["not_supported"] += 1
+        elif result.status == VideoTestStatus.CRASH:
+            codec_results[codec]["crash"] += 1
+        elif result.status == VideoTestStatus.SKIPPED:
+            codec_results[codec]["skipped"] += 1
+        else:
+            codec_results[codec]["fail"] += 1
+    return codec_results
+
+
+def result_to_dict(result: TestResult, test_type: str) -> dict:
+    """Convert a TestResult to a dictionary for JSON export."""
+    test_name = (result.config.display_name
+                 if hasattr(result.config, 'display_name')
+                 else result.config.name)
+    result_dict = {
+        "name": test_name,
+        "codec": result.config.codec.value,
+        "test_type": test_type,
+        "description": result.config.description,
+        "status": result.status.value,
+        "success": result.success,
+        "returncode": result.returncode,
+        "execution_time_ms": round(
+            result.execution_time * 1000, 2
+        ),
+        "warning_found": result.warning_found,
+        "warning_message": result.warning_message,
+        "error_message": result.error_message,
+        "command_line": result.command_line
+    }
+
+    if hasattr(result.config, 'full_path'):
+        result_dict["input_file"] = str(result.config.full_path)
+    elif hasattr(result.config, 'full_yuv_path'):
+        result_dict["input_file"] = str(result.config.full_yuv_path)
+
+    if hasattr(result.config, 'profile') and result.config.profile:
+        result_dict["profile"] = result.config.profile
+
+    return result_dict

--- a/tests/skipped_samples.json
+++ b/tests/skipped_samples.json
@@ -29,6 +29,7 @@
       "platforms": [
         "all"
       ],
+      "category": "hard_crash",
       "reproduction": "always",
       "reason": "Argon test - needs investigation, OBU frame header parsing issue.",
       "bug_url": "https://github.com/KhronosGroup/Vulkan-Video-Samples/issues/124",

--- a/vk_video_decoder/demos/vk-video-dec/Main.cpp
+++ b/vk_video_decoder/demos/vk-video-dec/Main.cpp
@@ -142,7 +142,7 @@ int main(int argc, const char **argv)
         }
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,
@@ -225,7 +225,7 @@ int main(int argc, const char **argv)
         }
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.cpp
@@ -787,6 +787,12 @@ int VkVideoDecoder::DecodePictureWithParameters(VkParserPerFrameDecodeParameters
         FAIL_WITH_RESULT(VK_ERROR_INITIALIZATION_FAILED, "decoder not initialized");
     }
 
+    // Codecs such as AV1 and H.265 create the video decode session from within the picture
+    // parser itself, so the frame processor cannot stop the dry run before this point.
+    if (m_dryRun) {
+        return -1;
+    }
+
     assert((m_videoFormat.codec == VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR) ||
            (pDecodePictureInfo->flags.applyFilmGrain == VK_FALSE));
 

--- a/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.h
+++ b/vk_video_decoder/libs/VkVideoDecoder/VkVideoDecoder.h
@@ -161,6 +161,8 @@ public:
 
     void SetVerbose(bool verbose) { m_verbose = verbose ? VK_TRUE : VK_FALSE; }
 
+    void SetDryRun(bool dryRun) { m_dryRun = dryRun ? VK_TRUE : VK_FALSE; }
+
     virtual int32_t AddRef();
     virtual int32_t Release();
 
@@ -174,6 +176,11 @@ public:
     }
 
     VkResult GetLastResult() const { return m_lastVkResult; }
+
+    /**
+    * @brief  Returns True once StartVideoSequence() has validated the stream against the device capabilities and created the video session.
+    */
+    bool IsVideoSequenceStarted() const { return m_videoFormat.coded_width != 0; }
 
     /**
     *   @brief  This callback function gets called when when decoding of sequence starts,
@@ -229,6 +236,7 @@ private:
         , m_resetDecoder(VK_TRUE)
         , m_dumpDecodeData(VK_FALSE)
         , m_verbose(VK_FALSE)
+        , m_dryRun(VK_FALSE)
         , m_numImageTypes(1) // At least the decoder requires images for DPB
         , m_numImageTypesEnabled(DecodeFrameBufferIf::IMAGE_TYPE_MASK_DECODE_DPB)
         , m_imageSpecsIndex()
@@ -336,6 +344,7 @@ private:
     uint32_t m_resetDecoder : 1;
     uint32_t m_dumpDecodeData : 1;
     uint32_t m_verbose : 1;
+    uint32_t m_dryRun : 1;
     uint32_t m_numImageTypes;
     uint32_t m_numImageTypesEnabled;
     DecodeFrameBufferIf::ImageSpecsIndex m_imageSpecsIndex;

--- a/vk_video_decoder/test/vulkan-video-dec/Main.cpp
+++ b/vk_video_decoder/test/vulkan-video-dec/Main.cpp
@@ -152,7 +152,7 @@ int main(int argc, const char** argv)
 
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,
@@ -232,7 +232,7 @@ int main(int argc, const char** argv)
         }
 
         VkSharedBaseObj<VkVideoFrameOutput> frameToFile;
-        if (!decoderConfig.outputFileName.empty()) {
+        if (!decoderConfig.outputFileName.empty() && !decoderConfig.dryRun) {
             const char* crcOutputFile = decoderConfig.outputcrcPerFrame ? decoderConfig.crcOutputFileName.c_str() : nullptr;
             result = VkVideoFrameOutput::Create(decoderConfig.outputFileName.c_str(),
                                               decoderConfig.outputy4m,

--- a/vk_video_encoder/demos/vk-video-enc/Main.cpp
+++ b/vk_video_encoder/demos/vk-video-enc/Main.cpp
@@ -296,6 +296,16 @@ int main(int argc, const char* argv[])
         }
     }
 
+    if (encoderConfig->dryRun) {
+        // The encoder is fully initialized at this point: the device is selected,
+        // the capabilities are validated against the requested profile and the
+        // video session exists. Report and stop before touching any input frame.
+        encoder->WaitForThreadsToComplete();
+        std::cout << "Dry run: encoder initialized successfully, no frame encoded."
+                  << std::endl;
+        return EXIT_SUCCESS;
+    }
+
     // Enter the encoding frame loop
     uint32_t curFrameIndex = 0;
     for(; curFrameIndex < encoderConfig->numFrames; curFrameIndex++) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.cpp
@@ -30,6 +30,7 @@ static void printHelp(VkVideoCodecOperationFlagBitsKHR codec)
     -o, --output                    .264/5,ivf Output H264/5/AV1 File Name \n\
     -c, --codec                     <string> select codec type: avc (h264) or hevc (h265) or av1\n\
     --verbose                       verbose output\n\
+    --dryRun                        initialize the encoder, then exit without encoding any frame\n\
     --dpbMode                       <string>  : select DPB mode: layered, separate\n\
     --inputWidth                    <integer> : Input Width \n\
     --inputHeight                   <integer> : Input Height \n\
@@ -197,10 +198,9 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
             if (!vk::IsValidFilePath(args[i].c_str(), false)) {
                 return -1;
             }
-            size_t fileSize = outputFileHandler.SetFileName(args[i].c_str());
-            if (fileSize <= 0) {
-                return (int)fileSize;
-            }
+            // Opening is deferred until the whole command line is parsed, so that
+            // --dryRun given after -o still avoids creating the file.
+            outputFileName = args[i];
         } else if (args[i] == "-h" || args[i] == "--help") {
             printHelp(codec);
             exit(EXIT_SUCCESS);
@@ -490,6 +490,10 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
                                "deviceUuid must be represented by 16 hex (32 bytes) values.", args[i].c_str(), args[i].length());
                 return -1;
             }
+        } else if (args[i] == "--dryRun") {
+            // Probe the hardware only: the encoder is fully initialized, then
+            // torn down without encoding any frame.
+            dryRun = true;
         } else if (args[i] == "--noDeviceFallback") {
             noDeviceFallback = true;
         } else if (args[i] == "--qpMap") {
@@ -596,7 +600,14 @@ int EncoderConfig::ParseArguments(int argc, const char *argv[])
         return -1;
     }
 
-    if (!outputFileHandler.HasFileName()) {
+    if (!outputFileName.empty()) {
+        size_t fileSize = outputFileHandler.SetFileName(outputFileName.c_str());
+        if (fileSize <= 0) {
+            return (int)fileSize;
+        }
+    }
+
+    if (!outputFileHandler.HasFileName() && !dryRun) {
         const char* defaultOutName = (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR) ? "out.264" :
                                      (codec == VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR) ? "out.265" : "out.ivf";
         if (verbose) {

--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfig.h
@@ -689,6 +689,7 @@ private:
 
 public:
     std::string appName;
+    std::string outputFileName;
     vk::DeviceUuidUtils deviceUUID;
     int32_t  deviceId;
     int32_t  queueId;
@@ -793,10 +794,12 @@ public:
     // 2: replicate only one row and one column to the padding area;
     uint32_t enablePictureRowColReplication : 2;
     uint32_t enableOutOfOrderRecording : 1; // Testing only - don't use for production!
+    uint32_t dryRun : 1;
 
     EncoderConfig()
     : refCount(0)
     , appName()
+    , outputFileName()
     , deviceId(-1)
     , queueId(0)
     , noDeviceFallback(false)
@@ -889,6 +892,7 @@ public:
     , enablePreprocessComputeFilter(true)
     , enablePictureRowColReplication(1)
     , enableOutOfOrderRecording(false)
+    , dryRun(false)
     { }
 
     virtual ~EncoderConfig() {}

--- a/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkVideoEncoderAV1.cpp
@@ -1192,7 +1192,9 @@ VkResult VkVideoEncoderAV1::Feedback2TextOutput::Init(const EncoderConfigAV1& co
     m_pictureEnabled = config.enablePictureFeedback || config.enablePixelCountFeedback || config.enablePerPartitionFeedback;
     m_partitionEnabled = config.enablePerPartitionFeedback;
 
-    if (!Enabled()) {
+    // A dry run stops before any frame is encoded, so opening the feedback
+    // file here would leave an empty one behind.
+    if (!Enabled() || config.dryRun) {
         return VK_SUCCESS;
     }
 

--- a/vk_video_encoder/src/vulkan_video_encoder.cpp
+++ b/vk_video_encoder/src/vulkan_video_encoder.cpp
@@ -26,6 +26,10 @@ public:
                                 int argc, const char** argv);
     virtual int64_t GetNumberOfFrames()
     {
+        // A dry run stops once initialization has succeeded, so no frame is encoded.
+        if (m_encoderConfig->dryRun) {
+            return 0;
+        }
         return m_encoderConfig->numFrames;
     }
     virtual VkResult EncodeNextFrame(int64_t& frameNumEncoded);
@@ -47,10 +51,17 @@ public:
             m_encoder->WaitForThreadsToComplete();
         }
 
-        if (m_encoderConfig && m_encoderConfig->verbose) {
-            std::cout << "Done processing " << m_lastFrameIndex << " input frames!" << std::endl
-                      << "Encoded file's location is at " << m_encoderConfig->outputFileHandler.GetFileName()
-                      << std::endl;
+        // Teardown also runs after a failed Initialize(), where neither the
+        // encoder nor the config is necessarily constructed.
+        if (m_encoder && m_encoderConfig) {
+            if (m_encoderConfig->dryRun) {
+                std::cout << "Dry run: encoder initialized successfully, no frame encoded."
+                          << std::endl;
+            } else if (m_encoderConfig->verbose) {
+                std::cout << "Done processing " << m_lastFrameIndex << " input frames!" << std::endl
+                          << "Encoded file's location is at " << m_encoderConfig->outputFileHandler.GetFileName()
+                          << std::endl;
+            }
         }
 
         m_encoder       = nullptr;


### PR DESCRIPTION
## Description

Add a way to dry run encode and decode process to detect the hardware before running the test, avoiding to crash the hardware such as with some tests.

So a dryRun detects the hardware and just skip the test to run only if the category is hard_crash.

## Type of change

feature

## Issue (optional)

<!-- e.g. Fixes #123 or Related to #456 -->

## Tests

<!-- Provide your GPU, driver, OS and test results in the format below -->

### AMD Radeon RX 7600 (RADV NAVI33) / radv Mesa 26.1.0-devel (git-16ece32984) / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         70
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         4 (in skip list)
Success Rate: 100.0%


## Additional Details (optional)

<!-- Any extra context: implementation notes, screenshots, logs, etc. -->
