### PR TITLE
VkEncoderConfigH264: fix use of B-frame count in profile autoselect logic

### DIFF
--- a/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
+++ b/vk_video_encoder/libs/VkVideoEncoder/VkEncoderConfigH264.cpp
@@ -371,6 +371,10 @@ StdVideoH264ProfileIdc EncoderConfigH264::GetNextLowerProfile(StdVideoH264Profil
 
 VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceContext* vkDevCtx)
 {
+    const uint8_t consecutiveBFrameCount = gopStructure.GetConsecutiveBFrameCount();
+    const uint8_t inputBFrames =
+        (consecutiveBFrameCount == CONSECUTIVE_B_FRAME_COUNT_MAX_VALUE) ? 0 : consecutiveBFrameCount;
+
     // Track whether the profile was user-specified or auto-selected.
     const bool autoSelected = (profileIdc == STD_VIDEO_H264_PROFILE_IDC_INVALID);
 
@@ -383,7 +387,7 @@ VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceConte
         profileIdc = STD_VIDEO_H264_PROFILE_IDC_BASELINE;
 
         // Upgrade to MAIN profile if using B-frames or CABAC entropy coding
-        if ((gopStructure.GetConsecutiveBFrameCount() > 0) || (entropyCodingMode == ENTROPY_CODING_MODE_CABAC))
+        if ((inputBFrames > 0) || (entropyCodingMode == ENTROPY_CODING_MODE_CABAC))
             profileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
 
         if (use8x8Transform) {
@@ -402,7 +406,7 @@ VkResult EncoderConfigH264::InitVideoProfileCapabilities(const VulkanDeviceConte
     if ((tuningMode == VK_VIDEO_ENCODE_TUNING_MODE_LOSSLESS_KHR) ||
         (encodeChromaSubsampling == VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR)) {
         minProfile = STD_VIDEO_H264_PROFILE_IDC_HIGH_444_PREDICTIVE;
-    } else if (gopStructure.GetConsecutiveBFrameCount() > 0) {
+    } else if (inputBFrames > 0) {
         minProfile = STD_VIDEO_H264_PROFILE_IDC_MAIN;
     }
 


### PR DESCRIPTION
## Description

The H.264 encoder profile auto-selection logic currently uses the value returned by VkVideoGopStructure::GetConsecutiveBFrameCount() for determining the lower and upper bounds on the codec profile which can be used for encoding the input content. However, this can end up selecting a higher profile than strictly necessary because GetConsecutiveBFrameCount() returns a default value of 255 (i.e. CONSECUTIVE_B_FRAME_COUNT_MAX_VALUE) when the user has not explicitly specified B-frames in the command line.

This change adds an extra check for this condition (in which case the B-frame count is set to 0 for use by the auto-selection logic).

## Type of change

Bug fix

## Tests

### NVIDIA L30 (10de:26bb) / NVIDIA 595.44.15 / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         72 (1 warning(s))
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         2 (in skip list)
Success Rate: 100.0%

## Additional Details (optional)

Follow-up to https://github.com/KhronosGroup/Vulkan-Video-Samples/pull/171