### PR TITLE
tests: skip decode av1_superres_8bit on some NVIDIA GPUs

### DIFF
--- a/tests/skipped_samples.json
+++ b/tests/skipped_samples.json
@@ -138,6 +138,23 @@
       "reason": "MD5 mismatch",
       "bug_url": "https://github.com/KhronosGroup/Vulkan-Video-Samples/issues/234",
       "date_added": "2026-08-20"
+    },
+    {
+      "name": "av1_superres_8bit",
+      "format": "vvs",
+      "drivers": [
+        "nvidia"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "reproduction": "always",
+      "reason": "fence timeout on certain GPUs",
+      "bug_url": "",
+      "date_added": "2026-09-08",
+      "devices": [
+        "26bb"
+      ]
     }
   ],
   "encode": [


### PR DESCRIPTION
## Description

This test encounters a fence timeout on some NVIDIA GPUs and eventually aborts (in a debug build of the encoder sample code) due to an assert about the fence getting signaled within the specified duration.

## Type of change

Bug fix

## Tests

### NVIDIA RTX A4000 (10de:24b0) / NVIDIA 595.44.15 / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         66 (1 warning(s))
Crashed:         0
Failed:          0
Not Supported:  18
Skipped:         1 (in skip list)
Success Rate: 100.0%

### NVIDIA L30 (10de:26bb) / NVIDIA 595.44.15 / Ubuntu 24.04.4 LTS

Total Tests:    85
Passed:         72 (1 warning(s))
Crashed:         0
Failed:          0
Not Supported:  11
Skipped:         2 (in skip list)
Success Rate: 100.0%